### PR TITLE
Problem: Participants cannot communicate directly when behing NATs

### DIFF
--- a/MPC/config/dcps_ice.mpb
+++ b/MPC/config/dcps_ice.mpb
@@ -1,0 +1,4 @@
+project: dcps, openssl {
+  after += OpenDDS_Ice
+  libs  += OpenDDS_Ice
+}

--- a/MPC/config/dcps_rtps.mpb
+++ b/MPC/config/dcps_rtps.mpb
@@ -1,4 +1,4 @@
-project : dcps {
+project: dcps, dcps_ice {
   after += OpenDDS_Rtps
   libs  += OpenDDS_Rtps
 }

--- a/dds/DCPS/DataReaderCallbacks.h
+++ b/dds/DCPS/DataReaderCallbacks.h
@@ -12,6 +12,8 @@
 #include "dds/DCPS/DiscoveryListener.h"
 #include "dds/DCPS/RcObject.h"
 
+#include "dds/DCPS/ICE/Ice.h"
+
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
@@ -59,6 +61,8 @@ public:
   virtual void unregister_for_writer(const RepoId& /*participant*/,
                                      const RepoId& /*readerid*/,
                                      const RepoId& /*writerid*/) { }
+
+  virtual ICE::Endpoint* get_ice_endpoint() = 0;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3275,6 +3275,12 @@ DataReaderImpl::unregister_for_writer(const RepoId& participant,
   TransportClient::unregister_for_writer(participant, readerid, writerid);
 }
 
+ICE::Endpoint*
+DataReaderImpl::get_ice_endpoint()
+{
+  return TransportClient::get_ice_endpoint();
+}
+
 void DataReaderImpl::accept_sample_processing(const SubscriptionInstance_rch& instance, const DataSampleHeader& header, bool is_new_instance)
 {
   bool accepted = true;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -557,6 +557,8 @@ public:
                                      const RepoId& /*readerid*/,
                                      const RepoId& /*writerid*/);
 
+  virtual ICE::Endpoint* get_ice_endpoint();
+
 protected:
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);
   void remove_publication(const PublicationId& pub_id);

--- a/dds/DCPS/DataWriterCallbacks.h
+++ b/dds/DCPS/DataWriterCallbacks.h
@@ -11,6 +11,8 @@
 #include "dds/DCPS/Definitions.h"
 #include "dds/DCPS/DiscoveryListener.h"
 #include "dds/DCPS/RcObject.h"
+#include "dds/DCPS/ICE/Ice.h"
+
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
@@ -60,6 +62,7 @@ public:
                                      const RepoId& /*writerid*/,
                                      const RepoId& /*readerid*/) { }
 
+  virtual ICE::Endpoint* get_ice_endpoint() = 0;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -2692,6 +2692,11 @@ DataWriterImpl::send_control(const DataSampleHeader& header,
   return status;
 }
 
+ICE::Endpoint*
+DataWriterImpl::get_ice_endpoint() {
+  return TransportClient::get_ice_endpoint();
+}
+
 int
 LivenessTimer::handle_timeout(const ACE_Time_Value &tv,
                              const void *arg)

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -463,6 +463,7 @@ public:
  PublicationInstance_rch get_handle_instance(
    DDS::InstanceHandle_t handle);
 
+ virtual ICE::Endpoint* get_ice_endpoint();
 
 protected:
 

--- a/dds/DCPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/ICE/AgentImpl.cpp
@@ -1,0 +1,196 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "AgentImpl.h"
+
+#include "dds/DCPS/Service_Participant.h"
+#include "Task.h"
+#include "EndpointManager.h"
+
+#include <iostream>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  bool AgentImpl::TaskCompare::operator() (Task const * x, Task const * y) const {
+    return x->m_release_time > y->m_release_time;
+  }
+
+  struct ScheduleTimerCommand : public DCPS::ReactorInterceptor::Command {
+    ACE_Reactor* reactor;
+    ACE_Event_Handler* event_handler;
+    ACE_Time_Value delay;
+
+    ScheduleTimerCommand(ACE_Reactor * a_reactor, ACE_Event_Handler * a_event_handler, ACE_Time_Value const & a_delay) :
+      reactor(a_reactor), event_handler(a_event_handler), delay(a_delay) {}
+
+    void execute() {
+      reactor->cancel_timer(event_handler, 0);
+      reactor->schedule_timer(event_handler, 0, delay);
+    }
+  };
+
+  void AgentImpl::enqueue(Task * a_task) {
+    if (!a_task->m_in_queue) {
+      m_tasks.push(a_task);
+      a_task->m_in_queue = true;
+      if (a_task == m_tasks.top()) {
+        ACE_Time_Value const delay = std::max(get_configuration().T_a(), a_task->m_release_time - ACE_Time_Value().now());
+        ScheduleTimerCommand c(reactor(), this, delay);
+        execute_or_enqueue(c);
+      }
+    }
+  }
+
+  bool AgentImpl::reactor_is_shut_down() const {
+    return TheServiceParticipant->is_shut_down();
+  }
+
+  int AgentImpl::handle_timeout(ACE_Time_Value const & a_now, const void* /*act*/) {
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, mutex, 0);
+    check_invariants();
+    if (m_tasks.empty()) {
+      return 0;
+    }
+
+    Task * task = m_tasks.top();
+    m_tasks.pop();
+    task->m_in_queue = false;
+
+    task->execute(a_now);
+
+    if (!m_tasks.empty()) {
+      ACE_Time_Value const delay = std::max(get_configuration().T_a(), m_tasks.top()->m_release_time - a_now);
+      ScheduleTimerCommand c(reactor(), this, delay);
+      execute_or_enqueue(c);
+    }
+
+    check_invariants();
+    return 0;
+  }
+
+  AgentImpl::AgentImpl() :
+    ReactorInterceptor(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner()),
+    m_remote_peer_reflexive_counter(0) {}
+
+  void AgentImpl::add_endpoint(Endpoint * a_endpoint) {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+    check_invariants();
+    if (m_endpoint_managers.find(a_endpoint) == m_endpoint_managers.end()) {
+      EndpointManager * em = new EndpointManager(this, a_endpoint);
+      m_endpoint_managers[a_endpoint] = em;
+    }
+    check_invariants();
+  }
+
+  void AgentImpl::remove_endpoint(Endpoint * a_endpoint) {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+    check_invariants();
+
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    if (pos != m_endpoint_managers.end()) {
+      EndpointManager * em = pos->second;
+      m_endpoint_managers.erase(pos);
+      em->schedule_for_destruction();
+    }
+    check_invariants();
+  }
+
+  AgentInfo AgentImpl::get_local_agent_info(Endpoint * a_endpoint) const {
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, const_cast<ACE_Recursive_Thread_Mutex&>(mutex), AgentInfo());
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    assert(pos != m_endpoint_managers.end());
+    return pos->second->agent_info();
+  }
+
+  void AgentImpl::add_local_agent_info_listener(Endpoint * a_endpoint,
+                                                DCPS::RepoId const & a_local_guid,
+                                                AgentInfoListener * a_agent_info_listener) {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    assert(pos != m_endpoint_managers.end());
+    pos->second->add_agent_info_listener(a_local_guid, a_agent_info_listener);
+  }
+
+  void AgentImpl::remove_local_agent_info_listener(Endpoint * a_endpoint,
+                                                   DCPS::RepoId const & a_local_guid) {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    assert(pos != m_endpoint_managers.end());
+    pos->second->remove_agent_info_listener(a_local_guid);
+  }
+
+  void  AgentImpl::start_ice(Endpoint * a_endpoint,
+                             DCPS::RepoId const & a_local_guid,
+                             DCPS::RepoId const & a_remote_guid,
+                             AgentInfo const & a_remote_agent_info) {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+    check_invariants();
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    assert(pos != m_endpoint_managers.end());
+    pos->second->start_ice(a_local_guid, a_remote_guid, a_remote_agent_info);
+    check_invariants();
+  }
+
+  void AgentImpl::stop_ice(Endpoint * a_endpoint,
+                           DCPS::RepoId const & a_local_guid,
+                           DCPS::RepoId const & a_remote_guid) {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+    check_invariants();
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    assert(pos != m_endpoint_managers.end());
+    pos->second->stop_ice(a_local_guid, a_remote_guid);
+    check_invariants();
+  }
+
+  ACE_INET_Addr  AgentImpl::get_address(Endpoint * a_endpoint,
+                                        DCPS::RepoId const & a_local_guid,
+                                        DCPS::RepoId const & a_remote_guid) const {
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, const_cast<ACE_Recursive_Thread_Mutex&>(mutex), ACE_INET_Addr());
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    assert(pos != m_endpoint_managers.end());
+    return pos->second->get_address(a_local_guid, a_remote_guid);
+  }
+
+  // Receive a STUN message.
+  void  AgentImpl::receive(Endpoint * a_endpoint,
+                           ACE_INET_Addr const & a_local_address,
+                           ACE_INET_Addr const & a_remote_address,
+                           const STUN::Message& a_message) {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+    check_invariants();
+    EndpointManagerMapType::const_iterator pos = m_endpoint_managers.find(a_endpoint);
+    assert(pos != m_endpoint_managers.end());
+    pos->second->receive(a_local_address, a_remote_address, a_message);
+    check_invariants();
+  }
+
+  void AgentImpl::unfreeze(FoundationType const & a_foundation) {
+    for (EndpointManagerMapType::const_iterator pos = m_endpoint_managers.begin(),
+           limit = m_endpoint_managers.end(); pos != limit; ++pos) {
+      pos->second->unfreeze(a_foundation);
+    }
+  }
+
+  void AgentImpl::check_invariants() const {
+    ActiveFoundationSet expected;
+
+    for (EndpointManagerMapType::const_iterator pos = m_endpoint_managers.begin(),
+           limit = m_endpoint_managers.end(); pos != limit; ++pos) {
+      pos->second->compute_active_foundations(expected);
+      pos->second->check_invariants();
+    }
+
+    assert(expected == active_foundations);
+  }
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ICE/AgentImpl.h
+++ b/dds/DCPS/ICE/AgentImpl.h
@@ -1,0 +1,129 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_AGENT_IMPL_H
+#define OPENDDS_RTPS_ICE_AGENT_IMPL_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include <ace/Time_Value.h>
+#include "dds/Versioned_Namespace.h"
+#include "dds/DCPS/ReactorInterceptor.h"
+#include "Ice.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  struct Task;
+  struct EndpointManager;
+
+  typedef std::pair<std::string, std::string> FoundationType;
+
+  class ActiveFoundationSet {
+  public:
+    void add(FoundationType const & a_foundation) {
+      std::pair<FoundationsType::iterator, bool> x = m_foundations.insert(std::make_pair(a_foundation, 0));
+      x.first->second += 1;
+    }
+
+    void remove(FoundationType const & a_foundation) {
+      FoundationsType::iterator pos = m_foundations.find(a_foundation);
+      assert(pos != m_foundations.end());
+      pos->second -= 1;
+      if (pos->second == 0) {
+        m_foundations.erase(pos);
+      }
+    }
+
+    bool contains(FoundationType const & a_foundation) const {
+      return m_foundations.find(a_foundation) != m_foundations.end();
+    }
+
+    bool operator==(ActiveFoundationSet const & a_other) const {
+      return m_foundations == a_other.m_foundations;
+    }
+
+  private:
+    typedef std::map<FoundationType, size_t> FoundationsType;
+    FoundationsType m_foundations;
+  };
+
+  class AgentImpl : public Agent, public DCPS::ReactorInterceptor {
+  public:
+    ActiveFoundationSet active_foundations;
+
+    AgentImpl();
+
+    Configuration & get_configuration() {
+      return m_configuration;
+    };
+
+    void add_endpoint(Endpoint * a_endpoint);
+
+    void remove_endpoint(Endpoint * a_endpoint);
+
+    AgentInfo get_local_agent_info(Endpoint * a_endpoint) const;
+
+    void add_local_agent_info_listener(Endpoint * a_endpoint,
+                                       DCPS::RepoId const & a_local_guid,
+                                       AgentInfoListener * a_agent_info_listener);
+
+    void remove_local_agent_info_listener(Endpoint * a_endpoint,
+                                          DCPS::RepoId const & a_local_guid);
+
+    void start_ice(Endpoint * a_endpoint,
+                   DCPS::RepoId const & a_local_guid,
+                   DCPS::RepoId const & a_remote_guid,
+                   AgentInfo const & a_remote_agent_info);
+
+    void stop_ice(Endpoint * a_endpoint,
+                  DCPS::RepoId const & a_local_guid,
+                  DCPS::RepoId const & a_remote_guid);
+
+    ACE_INET_Addr get_address(Endpoint * a_endpoint,
+                              DCPS::RepoId const & a_local_guid,
+                              DCPS::RepoId const & a_remote_guid) const;
+
+    void receive(Endpoint * a_endpoint,
+                 ACE_INET_Addr const & a_local_address,
+                 ACE_INET_Addr const & a_remote_address,
+                 STUN::Message const & a_message);
+
+    void enqueue(Task * a_task);
+
+    size_t remote_peer_reflexive_counter() { return m_remote_peer_reflexive_counter++; };
+
+    void unfreeze(FoundationType const & a_foundation);
+
+    ACE_Recursive_Thread_Mutex mutex;
+
+  private:
+    Configuration m_configuration;
+    size_t m_remote_peer_reflexive_counter;
+    typedef std::map<Endpoint *, EndpointManager *> EndpointManagerMapType;
+    EndpointManagerMapType m_endpoint_managers;
+    struct TaskCompare {
+      bool operator() (Task const * x, Task const * y) const;
+    };
+    std::priority_queue<Task *, std::vector<Task*>, TaskCompare> m_tasks;
+
+    bool reactor_is_shut_down() const;
+    int handle_timeout(ACE_Time_Value const & a_now, const void* /*act*/);
+
+    void check_invariants() const;
+  };
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_AGENT_IMPL_H */

--- a/dds/DCPS/ICE/Checklist.cpp
+++ b/dds/DCPS/ICE/Checklist.cpp
@@ -1,0 +1,713 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Checklist.h"
+
+#include "EndpointManager.h"
+
+#include <iostream>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  const uint32_t PEER_REFLEXIVE_PRIORITY = (110 << 24) + (65535 << 8) + ((256 - 1) << 0);  // No local preference, component 1.
+
+  CandidatePair::CandidatePair(const Candidate& a_local,
+                               const Candidate& a_remote,
+                               bool a_local_is_controlling,
+                               bool a_use_candidate)
+    : local(a_local),
+      remote(a_remote),
+      foundation(std::make_pair(a_local.foundation, a_remote.foundation)),
+      local_is_controlling(a_local_is_controlling),
+      priority(compute_priority()),
+      use_candidate(a_use_candidate) {
+    assert(!a_local.foundation.empty());
+    assert(!a_remote.foundation.empty());
+  }
+
+  bool CandidatePair::operator==(const CandidatePair& other) const {
+    return
+      this->local == other.local &&
+      this->remote == other.remote &&
+      this->use_candidate == other.use_candidate;
+  }
+
+  uint64_t CandidatePair::compute_priority() {
+    uint64_t const g = local_is_controlling ? local.priority : remote.priority;
+    uint64_t const d = local_is_controlling ? remote.priority : local.priority;
+    return (std::min(g,d) << 32) + 2 * std::max(g,d) + (g > d ? 1 : 0);
+  }
+
+  ConnectivityCheck::ConnectivityCheck(CandidatePair const & a_candidate_pair,
+                                       AgentInfo const & a_local_agent_info, AgentInfo const & a_remote_agent_info,
+                                       uint64_t a_ice_tie_breaker, ACE_Time_Value const & a_expiration_date)
+    : m_candidate_pair(a_candidate_pair), m_cancelled(false), m_expiration_date(a_expiration_date) {
+    m_request.class_ = STUN::REQUEST;
+    m_request.method = STUN::BINDING;
+    m_request.generate_transaction_id();
+    m_request.append_attribute(STUN::make_priority(PEER_REFLEXIVE_PRIORITY));
+    if (a_candidate_pair.local_is_controlling) {
+      m_request.append_attribute(STUN::make_ice_controlling(a_ice_tie_breaker));
+    } else {
+      m_request.append_attribute(STUN::make_ice_controlled(a_ice_tie_breaker));
+    }
+    if (a_candidate_pair.local_is_controlling && a_candidate_pair.use_candidate) {
+      m_request.append_attribute(STUN::make_use_candidate());
+    }
+    m_request.append_attribute(STUN::make_username(a_remote_agent_info.username + ":" + a_local_agent_info.username));
+    m_request.password = a_remote_agent_info.password;
+    m_request.append_attribute(STUN::make_message_integrity());
+    m_request.append_attribute(STUN::make_fingerprint());
+  }
+
+  Checklist::Checklist(EndpointManager * a_endpoint_manager,
+                       AgentInfo const & local, AgentInfo const & remote, ACE_UINT64 a_ice_tie_breaker)
+    : Task(a_endpoint_manager->agent_impl)
+    , m_scheduled_for_destruction(false)
+    , m_endpoint_manager(a_endpoint_manager)
+    , m_local_agent_info(local)
+    , m_remote_agent_info(remote)
+    , m_original_remote_agent_info(remote)
+    , m_local_is_controlling(local.username < remote.username)
+    , m_ice_tie_breaker(a_ice_tie_breaker)
+    , m_nominating(m_valid_list.end())
+    , m_nominated(m_valid_list.end())
+    , m_nominated_is_live(false)
+  {
+    m_endpoint_manager->set_responsible_checklist(m_remote_agent_info.username, this);
+
+    generate_candidate_pairs();
+  }
+
+  void Checklist::reset() {
+    fix_foundations();
+
+    for (ConnectivityChecksType::const_iterator pos = m_connectivity_checks.begin(),
+           limit = m_connectivity_checks.end(); pos != limit; ++pos) {
+      m_endpoint_manager->unset_responsible_checklist(pos->request().transaction_id, this);
+    }
+
+    m_frozen.clear();
+    m_waiting.clear();
+    m_in_progress.clear();
+    m_succeeded.clear();
+    m_failed.clear();
+    m_triggered_check_queue.clear();
+    m_valid_list.clear();
+    m_nominating = m_valid_list.end();
+    m_nominated = m_valid_list.end();
+    m_nominated_is_live = false;
+    m_check_interval = ACE_Time_Value();
+    m_max_check_interval = ACE_Time_Value();
+    m_connectivity_checks.clear();
+  }
+
+  void Checklist::generate_candidate_pairs() {
+    // Add the candidate pairs.
+    for (AgentInfo::CandidatesType::const_iterator local_pos = m_local_agent_info.candidates.begin(), local_limit = m_local_agent_info.candidates.end(); local_pos != local_limit; ++local_pos) {
+      for (AgentInfo::CandidatesType::const_iterator remote_pos = m_remote_agent_info.candidates.begin(), remote_limit = m_remote_agent_info.candidates.end(); remote_pos != remote_limit; ++remote_pos) {
+        m_frozen.push_back(CandidatePair(*local_pos, *remote_pos, m_local_is_controlling));
+      }
+    }
+
+    // Sort by priority.
+    m_frozen.sort(CandidatePair::priority_sorted);
+
+    // Eliminate duplicates.
+    for (CandidatePairsType::iterator pos = m_frozen.begin(), limit = m_frozen.end(); pos != limit; ++pos) {
+      CandidatePairsType::iterator test_pos = pos;
+      ++test_pos;
+      while (test_pos != limit) {
+        if (pos->local.base == test_pos->local.base && pos->remote == test_pos->remote) {
+          m_frozen.erase(test_pos++);
+        } else {
+          ++test_pos;
+        }
+      }
+    }
+
+    if (m_frozen.size() != 0) {
+      m_check_interval = m_endpoint_manager->agent_impl->get_configuration().T_a();
+      double s = m_frozen.size();
+      m_max_check_interval = m_endpoint_manager->agent_impl->get_configuration().checklist_period() * (1.0 / s);
+      enqueue(ACE_Time_Value().now());
+    }
+  }
+
+  void Checklist::compute_active_foundations(ActiveFoundationSet& active_foundations) const {
+    for (CandidatePairsType::const_iterator pos = m_waiting.begin(), limit = m_waiting.end(); pos != limit; ++pos) {
+      active_foundations.add(pos->foundation);
+    }
+    for (CandidatePairsType::const_iterator pos = m_in_progress.begin(), limit = m_in_progress.end(); pos != limit; ++pos) {
+      active_foundations.add(pos->foundation);
+    }
+  }
+
+  void Checklist::check_invariants() const {
+    for (CandidatePairsType::const_iterator pos = m_valid_list.begin(), limit = m_valid_list.end(); pos != limit; ++pos) {
+      assert(pos->use_candidate);
+    }
+  }
+
+  void Checklist::unfreeze() {
+    for (CandidatePairsType::const_iterator pos = m_frozen.begin(), limit = m_frozen.end(); pos != limit;) {
+      const CandidatePair& cp = *pos;
+      if (!m_endpoint_manager->agent_impl->active_foundations.contains(cp.foundation)) {
+        m_endpoint_manager->agent_impl->active_foundations.add(cp.foundation);
+        m_waiting.push_back(cp);
+        m_waiting.sort(CandidatePair::priority_sorted);
+        m_frozen.erase(pos++);
+      } else {
+        ++pos;
+      }
+    }
+  }
+
+  void Checklist::unfreeze(FoundationType const & a_foundation) {
+    for (CandidatePairsType::const_iterator pos = m_frozen.begin(), limit = m_frozen.end(); pos != limit;) {
+      const CandidatePair& cp = *pos;
+      if (cp.foundation == a_foundation) {
+        m_endpoint_manager->agent_impl->active_foundations.add(cp.foundation);
+        m_waiting.push_back(cp);
+        m_waiting.sort(CandidatePair::priority_sorted);
+        m_frozen.erase(pos++);
+      } else {
+        ++pos;
+      }
+    }
+  }
+
+  void Checklist::add_valid_pair(const CandidatePair& valid_pair) {
+    assert(valid_pair.use_candidate);
+    m_valid_list.push_back(valid_pair);
+    m_valid_list.sort(CandidatePair::priority_sorted);
+  }
+
+  void Checklist::fix_foundations() {
+    for (CandidatePairsType::const_iterator pos = m_waiting.begin(), limit = m_waiting.end(); pos != limit; ++pos) {
+      m_endpoint_manager->agent_impl->active_foundations.remove(pos->foundation);
+    }
+    for (CandidatePairsType::const_iterator pos = m_in_progress.begin(), limit = m_in_progress.end(); pos != limit; ++pos) {
+      m_endpoint_manager->agent_impl->active_foundations.remove(pos->foundation);
+    }
+  }
+
+  bool Checklist::get_local_candidate(const ACE_INET_Addr& address, Candidate& candidate) {
+    for (AgentInfo::const_iterator pos = m_local_agent_info.begin(), limit = m_local_agent_info.end(); pos != limit; ++pos) {
+      if (pos->address == address) {
+        candidate = *pos;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool Checklist::get_remote_candidate(const ACE_INET_Addr& address, Candidate& candidate) {
+    for (AgentInfo::const_iterator pos = m_remote_agent_info.begin(), limit = m_remote_agent_info.end(); pos != limit; ++pos) {
+      if (pos->address == address) {
+        candidate = *pos;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void Checklist::add_triggered_check(CandidatePair const & a_candidate_pair) {
+    if (m_nominated != m_valid_list.end()) {
+      // Don't generate a check when we are done.
+      return;
+    }
+
+    CandidatePairsType::const_iterator pos;
+
+    pos = std::find(m_frozen.begin(), m_frozen.end(), a_candidate_pair);
+    if (pos != m_frozen.end()) {
+      m_frozen.erase(pos);
+      m_endpoint_manager->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+      m_waiting.push_back(a_candidate_pair);
+      m_waiting.sort(CandidatePair::priority_sorted);
+      m_triggered_check_queue.push_back(a_candidate_pair);
+      return;
+    }
+
+    pos = std::find(m_waiting.begin(), m_waiting.end(), a_candidate_pair);
+    if (pos != m_waiting.end()) {
+      // Done.
+      return;
+    }
+
+    pos = std::find(m_in_progress.begin(), m_in_progress.end(), a_candidate_pair);
+    if (pos != m_in_progress.end()) {
+      // Duplicating to waiting.
+      m_endpoint_manager->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+      m_waiting.push_back(a_candidate_pair);
+      m_waiting.sort(CandidatePair::priority_sorted);
+      m_triggered_check_queue.push_back(a_candidate_pair);
+      return;
+    }
+
+    pos = std::find(m_succeeded.begin(), m_succeeded.end(), a_candidate_pair);
+    if (pos != m_succeeded.end()) {
+      // Done.
+      return;
+    }
+
+    pos = std::find(m_failed.begin(), m_failed.end(), a_candidate_pair);
+    if (pos != m_failed.end()) {
+      m_failed.erase(pos);
+      m_endpoint_manager->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+      m_waiting.push_back(a_candidate_pair);
+      m_waiting.sort(CandidatePair::priority_sorted);
+      m_triggered_check_queue.push_back(a_candidate_pair);
+      return;
+    }
+
+    // Not in checklist.
+    m_endpoint_manager->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+    m_waiting.push_back(a_candidate_pair);
+    m_waiting.sort(CandidatePair::priority_sorted);
+    m_triggered_check_queue.push_back(a_candidate_pair);
+  }
+
+  void Checklist::remove_from_in_progress(CandidatePair const & a_candidate_pair) {
+    m_endpoint_manager->agent_impl->active_foundations.remove(a_candidate_pair.foundation);
+    // Candidates can be in progress multiple times.
+    CandidatePairsType::const_iterator pos = std::find(m_in_progress.begin(), m_in_progress.end(), a_candidate_pair);
+    m_in_progress.erase(pos);
+  }
+
+  void Checklist::generate_triggered_check(const ACE_INET_Addr& local_address, const ACE_INET_Addr& remote_address,
+                                           uint32_t priority,
+                                           bool use_candidate) {
+    Candidate remote;
+
+    if (!get_remote_candidate(remote_address, remote)) {
+      // 7.3.1.3
+      remote = make_peer_reflexive_candidate(remote_address, priority, m_endpoint_manager->agent_impl->remote_peer_reflexive_counter());
+      m_remote_agent_info.candidates.push_back(remote);
+      std::sort(m_remote_agent_info.candidates.begin (), m_remote_agent_info.candidates.end (), candidates_sorted);
+    }
+
+    // 7.3.1.4
+    Candidate local;
+    bool flag = get_local_candidate(local_address, local);
+    assert(flag);
+
+    CandidatePair cp(local, remote, m_local_is_controlling, use_candidate);
+
+    if (is_succeeded(cp)) {
+      return;
+    }
+
+    if (is_in_progress(cp)) {
+      ConnectivityChecksType::iterator pos = std::find(m_connectivity_checks.begin(), m_connectivity_checks.end(), cp);
+      pos->cancel();
+    }
+
+    add_triggered_check(cp);
+    // This can move something from failed to in progress.
+    // In that case, we need to schedule.
+    m_check_interval = m_endpoint_manager->agent_impl->get_configuration().T_a();
+    enqueue(ACE_Time_Value().now());
+  }
+
+  void Checklist::succeeded(const ConnectivityCheck& cc) {
+    const CandidatePair& cp = cc.candidate_pair();
+
+    // 7.2.5.3.3
+    // 7.2.5.4
+
+    remove_from_in_progress(cp);
+    m_succeeded.push_back(cp);
+    m_succeeded.sort(CandidatePair::priority_sorted);
+
+    if (cp.use_candidate) {
+      if (m_local_is_controlling) {
+        m_nominated = m_nominating;
+        m_nominating = m_valid_list.end();
+        assert(m_frozen.empty());
+        assert(m_waiting.empty());
+      } else {
+        m_nominated = std::find(m_valid_list.begin(), m_valid_list.end(), cp);
+        // This is the case where the use_candidate check succeeded before the normal check.
+        if (m_nominated == m_valid_list.end()) {
+          m_valid_list.push_front(cp);
+          m_nominated = m_valid_list.begin();
+        }
+
+        while (!m_frozen.empty()) {
+          CandidatePair cp = m_frozen.front();
+          m_frozen.pop_front();
+          m_failed.push_back(cp);
+        }
+
+        while (!m_waiting.empty()) {
+          CandidatePair cp = m_waiting.front();
+          m_waiting.pop_front();
+          m_endpoint_manager->agent_impl->active_foundations.remove(cp.foundation);
+          m_failed.push_back(cp);
+        }
+        m_triggered_check_queue.clear();
+      }
+
+      m_nominated_is_live = true;
+      m_last_indication = ACE_Time_Value().now();
+
+      while (!m_connectivity_checks.empty()) {
+        ConnectivityCheck cc = m_connectivity_checks.front();
+        m_connectivity_checks.pop_front();
+
+        if (!cc.cancelled()) {
+          failed(cc);
+        } else {
+          remove_from_in_progress(cc.candidate_pair());
+        }
+      }
+
+      assert(m_frozen.empty());
+      assert(m_waiting.empty());
+      assert(m_triggered_check_queue.empty());
+      assert(m_in_progress.empty());
+      assert(m_connectivity_checks.empty());
+    }
+
+    m_endpoint_manager->agent_impl->unfreeze(cp.foundation);
+  }
+
+  void Checklist::failed(const ConnectivityCheck& cc) {
+    const CandidatePair& cp = cc.candidate_pair();
+    // 7.2.5.4
+    remove_from_in_progress(cp);
+    m_failed.push_back(cp);
+    m_failed.sort(CandidatePair::priority_sorted);
+
+    if (cp.use_candidate && m_local_is_controlling) {
+      m_valid_list.pop_front();
+      m_nominating = m_valid_list.end();
+    }
+  }
+
+  void Checklist::success_response(ACE_INET_Addr const & local_address,
+                                   ACE_INET_Addr const & remote_address,
+                                   STUN::Message const & a_message) {
+    ConnectivityChecksType::const_iterator pos = std::find(m_connectivity_checks.begin(), m_connectivity_checks.end(), a_message.transaction_id);
+    assert(pos != m_connectivity_checks.end());
+
+    ConnectivityCheck const cc = *pos;
+
+    std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+    if (!unknown_attributes.empty()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING Unknown comprehension required attributes\n")));
+      failed(cc);
+      m_connectivity_checks.erase(pos);
+      m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      return;
+    }
+
+    if (!a_message.has_fingerprint()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No FINGERPRINT attribute\n")));
+      failed(cc);
+      m_connectivity_checks.erase(pos);
+      m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      return;
+    }
+
+    ACE_INET_Addr mapped_address;
+    if (!a_message.get_mapped_address(mapped_address)) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No (XOR_)MAPPED_ADDRESS attribute\n")));
+      failed(cc);
+      m_connectivity_checks.erase(pos);
+      m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      return;
+    }
+
+    if (!a_message.has_message_integrity()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No MESSAGE_INTEGRITY attribute\n")));
+      failed(cc);
+      m_connectivity_checks.erase(pos);
+      m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      return;
+    }
+
+    // Require integrity for checks.
+    if (!a_message.verify_message_integrity(cc.request().password)) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING MESSAGE_INTEGRITY check failed\n")));
+      failed(cc);
+      m_connectivity_checks.erase(pos);
+      m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      return;
+    }
+
+    // At this point the check will either succeed or fail so remove from the list.
+    m_connectivity_checks.erase(pos);
+    m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+
+    const CandidatePair& cp = cc.candidate_pair();
+
+    if (remote_address != cp.remote.address || local_address != cp.local.base) {
+      // 7.2.5.2.1 Non-Symmetric Transport Addresses
+      failed(cc);
+      return;
+    }
+
+    succeeded(cc);
+
+    if (cp.use_candidate) {
+      return;
+    }
+
+    // 7.2.5.3.2 Constructing a Valid Pair
+    Candidate local;
+
+    if (!get_local_candidate(mapped_address, local)) {
+      // 7.2.5.3.1 Discovering Peer-Reflexive Candidates
+      uint32_t priority;
+      // Our message, no need to check.
+      cc.request().get_priority(priority);
+      local = make_peer_reflexive_candidate(mapped_address, cp.local.base, cp.remote.address, priority);
+      m_local_agent_info.candidates.push_back(local);
+      std::sort(m_local_agent_info.candidates.begin (), m_local_agent_info.candidates.end (), candidates_sorted);
+    }
+
+    // The valid pair
+    CandidatePair vp(local, cp.remote, m_local_is_controlling, true);
+
+    add_valid_pair(vp);
+  }
+
+  void Checklist::error_response(ACE_INET_Addr const & /*local_address*/,
+                                 ACE_INET_Addr const & /*remote_address*/,
+                                 STUN::Message const & a_message) {
+    ConnectivityChecksType::const_iterator pos = std::find(m_connectivity_checks.begin(), m_connectivity_checks.end(), a_message.transaction_id);
+    assert(pos != m_connectivity_checks.end());
+
+    ConnectivityCheck const cc = *pos;
+
+    if (!a_message.has_message_integrity()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING No MESSAGE_INTEGRITY attribute\n")));
+      // Retry.
+      return;
+    }
+
+    if (!a_message.verify_message_integrity(cc.request().password)) {
+      // Retry.
+      return;
+    }
+
+    // We have a verified error response.
+    std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+    if (!unknown_attributes.empty()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING Unknown comprehension required attributes\n")));
+      failed(cc);
+      m_connectivity_checks.erase(pos);
+      m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      return;
+    }
+
+    if (!a_message.has_fingerprint()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING No FINGERPRINT attribute\n")));
+      failed(cc);
+      m_connectivity_checks.erase(pos);
+      m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      return;
+    }
+
+    if (a_message.has_error_code()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING STUN error response code=%d reason=%s\n"), a_message.get_error_code(), a_message.get_error_reason().c_str()));
+      if (a_message.get_error_code() == 420 && a_message.has_unknown_attributes()) {
+        std::vector<STUN::AttributeType> unknown_attributes = a_message.get_unknown_attributes();
+        for (std::vector<STUN::AttributeType>::const_iterator pos = unknown_attributes.begin(),
+               limit = unknown_attributes.end(); pos != limit; ++pos) {
+          ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING Unknown STUN attribute %d\n"), *pos));
+        }
+      }
+      if (a_message.get_error_code() == 400 && a_message.get_error_code() == 420) {
+        // Waiting and/or resending won't fix these errors.
+        failed(cc);
+        m_connectivity_checks.erase(pos);
+        m_endpoint_manager->unset_responsible_checklist(cc.request().transaction_id, this);
+      }
+    } else {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING STUN error response (no code)\n")));
+    }
+  }
+
+  void Checklist::do_next_check(ACE_Time_Value const & a_now) {
+    // Triggered checks.
+    if (!m_triggered_check_queue.empty()) {
+      CandidatePair cp = m_triggered_check_queue.front();
+      m_triggered_check_queue.pop_front();
+
+      ConnectivityCheck cc(cp, m_local_agent_info, m_remote_agent_info, m_ice_tie_breaker, a_now + m_endpoint_manager->agent_impl->get_configuration().connectivity_check_ttl());
+
+      m_waiting.remove(cp);
+      m_in_progress.push_back(cp);
+      m_in_progress.sort(CandidatePair::priority_sorted);
+
+      m_endpoint_manager->endpoint->send(cc.candidate_pair().remote.address, cc.request());
+      m_connectivity_checks.push_back(cc);
+      m_endpoint_manager->set_responsible_checklist(cc.request().transaction_id, this);
+      m_check_interval = m_endpoint_manager->agent_impl->get_configuration().T_a();
+      return;
+    }
+
+    unfreeze();
+
+    // Ordinary check.
+    if (!m_waiting.empty()) {
+      CandidatePair cp = m_waiting.front();
+      m_waiting.pop_front();
+
+      ConnectivityCheck cc(cp, m_local_agent_info, m_remote_agent_info, m_ice_tie_breaker, a_now + m_endpoint_manager->agent_impl->get_configuration().connectivity_check_ttl());
+
+      m_in_progress.push_back(cp);
+      m_in_progress.sort(CandidatePair::priority_sorted);
+
+      m_endpoint_manager->endpoint->send(cc.candidate_pair().remote.address, cc.request());
+      m_connectivity_checks.push_back(cc);
+      m_endpoint_manager->set_responsible_checklist(cc.request().transaction_id, this);
+      m_check_interval = m_endpoint_manager->agent_impl->get_configuration().T_a();
+      return;
+    }
+
+    // Retry.
+    while (!m_connectivity_checks.empty()) {
+      ConnectivityCheck cc = m_connectivity_checks.front();
+      m_connectivity_checks.pop_front();
+
+      if (cc.expiration_date() < a_now) {
+        if (!cc.cancelled()) {
+          // Failing can allow nomination to proceed.
+          failed(cc);
+        } else {
+          remove_from_in_progress(cc.candidate_pair());
+        }
+        continue;
+      }
+
+      // We leave the cancelled checks in case we get a response.
+      if (!cc.cancelled()) {
+        // Reset the password in the event that it changed.
+        cc.password(m_remote_agent_info.password);
+        m_endpoint_manager->endpoint->send(cc.candidate_pair().remote.address, cc.request());
+      }
+      m_connectivity_checks.push_back(cc);
+
+      // Backoff.
+      m_check_interval = std::min(m_check_interval * 2, m_max_check_interval);
+      break;
+    }
+
+    // Waiting for the remote.
+    m_check_interval = m_endpoint_manager->agent_impl->get_configuration().checklist_period();
+  }
+
+  void Checklist::execute(ACE_Time_Value const & a_now) {
+    if (m_scheduled_for_destruction) {
+      delete this;
+      return;
+    }
+
+    // Nominating check.
+    if (m_frozen.empty() &&
+        m_waiting.empty() &&
+        // m_in_progress.empty() &&
+        m_local_is_controlling &&
+        !m_valid_list.empty() &&
+        m_nominating == m_valid_list.end() &&
+        m_nominated == m_valid_list.end()) {
+      add_triggered_check(m_valid_list.front());
+      m_nominating = m_valid_list.begin();
+    }
+
+    bool flag = false;
+    ACE_Time_Value interval = std::max(m_check_interval, m_endpoint_manager->agent_impl->get_configuration().indication_period());
+
+    if (!m_triggered_check_queue.empty() ||
+        !m_frozen.empty() ||
+        !m_waiting.empty() ||
+        !m_connectivity_checks.empty()) {
+      do_next_check(a_now);
+      flag = true;
+      interval = std::min(interval, m_check_interval);
+    }
+
+    if (m_nominated != m_valid_list.end()) {
+      // Send an indication.
+      STUN::Message message;
+      message.class_ = STUN::INDICATION;
+      message.method = STUN::BINDING;
+      message.generate_transaction_id();
+      message.append_attribute(STUN::make_username(m_remote_agent_info.username + ":" + m_local_agent_info.username));
+      message.password = m_remote_agent_info.password;
+      message.append_attribute(STUN::make_message_integrity());
+      message.append_attribute(STUN::make_fingerprint());
+      m_endpoint_manager->endpoint->send(selected_address(), message);
+      flag = true;
+      interval = std::min(interval, m_endpoint_manager->agent_impl->get_configuration().indication_period());
+
+      // Check that we are receiving indications.
+      m_nominated_is_live = (a_now - m_last_indication) < m_endpoint_manager->agent_impl->get_configuration().nominated_ttl();
+    }
+
+    if (flag) {
+      enqueue(ACE_Time_Value().now() + interval);
+    }
+
+    // The checklist has failed.  Don't schedule.
+  }
+
+  void Checklist::add_guid(GuidPair const & a_guid_pair) {
+    m_guids.insert(a_guid_pair);
+    m_endpoint_manager->set_responsible_checklist(a_guid_pair, this);
+  }
+
+  void Checklist::remove_guid(GuidPair const & a_guid_pair) {
+    m_guids.erase(a_guid_pair);
+    m_endpoint_manager->unset_responsible_checklist(a_guid_pair, this);
+    if (m_guids.empty()) {
+      // Cleanup this checklist.
+      m_endpoint_manager->unset_responsible_checklist(m_remote_agent_info.username, this);
+      reset();
+      m_scheduled_for_destruction = true;
+
+      // Flush ourselves out of the task queue.
+      // Schedule for now but it may be later.
+      enqueue(ACE_Time_Value().now());
+    }
+  }
+
+  void Checklist::add_guids(GuidSetType const & a_guids) {
+    for (GuidSetType::const_iterator pos = a_guids.begin(), limit = a_guids.end(); pos != limit; ++pos) {
+      add_guid(*pos);
+    }
+  }
+
+  void Checklist::remove_guids() {
+    GuidSetType guids = m_guids;
+    for (GuidSetType::const_iterator pos = guids.begin(), limit = guids.end(); pos != limit; ++pos) {
+      remove_guid(*pos);
+    }
+  }
+
+  ACE_INET_Addr Checklist::selected_address() const {
+    if (m_nominated_is_live && m_nominated != m_valid_list.end()) {
+      return m_nominated->remote.address;
+    }
+    return ACE_INET_Addr();
+  }
+
+  void Checklist::indication() {
+    m_last_indication = ACE_Time_Value().now();
+  }
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ICE/Checklist.h
+++ b/dds/DCPS/ICE/Checklist.h
@@ -1,0 +1,215 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_CHECKLIST_H
+#define OPENDDS_RTPS_ICE_CHECKLIST_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include "Task.h"
+#include "AgentImpl.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  struct CandidatePair {
+    Candidate const local;
+    Candidate const remote;
+    FoundationType const foundation;
+    bool const local_is_controlling;
+    uint64_t const priority;
+    // 1) set the use_candidate when local is controlling and
+    // 2) nominate when the response is successful (controlling and controlled)
+    bool const use_candidate;
+
+    CandidatePair(Candidate const & a_local,
+                  Candidate const & a_remote,
+                  bool a_local_is_controlling,
+                  bool a_use_candidate = false);
+
+    bool operator==(CandidatePair const & a_other) const;
+
+    static bool priority_sorted(CandidatePair const & x, CandidatePair const & y) { return x.priority > y.priority; }
+
+  private:
+    uint64_t compute_priority();
+  };
+
+  struct ConnectivityCheck {
+    ConnectivityCheck(CandidatePair const & a_candidate_pair,
+                      AgentInfo const & a_local_agent_info, AgentInfo const & a_remote_agent_info,
+                      uint64_t a_ice_tie_breaker, ACE_Time_Value const & a_expiration_date);
+
+    CandidatePair const & candidate_pair() const { return m_candidate_pair; }
+    STUN::Message const & request() const { return m_request; }
+    void cancel() { m_cancelled = true; }
+    bool cancelled() const { return m_cancelled; }
+    ACE_Time_Value expiration_date() const { return m_expiration_date; }
+    void password(std::string const & a_password) { m_request.password = a_password; }
+  private:
+    CandidatePair m_candidate_pair;
+    STUN::Message m_request;
+    bool m_cancelled;
+    ACE_Time_Value m_expiration_date;
+  };
+
+  inline bool operator==(ConnectivityCheck const & a_cc, STUN::TransactionId const & a_tid) {
+    return a_cc.request().transaction_id == a_tid;
+  }
+
+  inline bool operator==(ConnectivityCheck const & a_cc, CandidatePair const & a_cp) {
+    return a_cc.candidate_pair() == a_cp;
+  }
+
+  struct GuidPair {
+    DCPS::RepoId local;
+    DCPS::RepoId remote;
+
+    GuidPair(DCPS::RepoId const & a_local, DCPS::RepoId const & a_remote) : local(a_local), remote(a_remote) {}
+
+    bool operator< (GuidPair const & a_other) const {
+      if (DCPS::GUID_tKeyLessThan() (this->local, a_other.local)) return true;
+      if (DCPS::GUID_tKeyLessThan() (a_other.local, this->local)) return false;
+      if (DCPS::GUID_tKeyLessThan() (this->remote, a_other.remote)) return true;
+      if (DCPS::GUID_tKeyLessThan() (a_other.remote, this->remote)) return false;
+      return false;
+    }
+  };
+
+  inline std::ostream& operator<<(std::ostream& stream, GuidPair const & guidp) {
+    stream << guidp.local << ':' << guidp.remote;
+    return stream;
+  }
+
+  typedef std::set<GuidPair> GuidSetType;
+
+  struct Checklist : public Task {
+    Checklist(EndpointManager * a_endpoint,
+              AgentInfo const & a_local, AgentInfo const & a_remote,
+              ACE_UINT64 a_ice_tie_breaker);
+
+    void compute_active_foundations(ActiveFoundationSet & a_active_foundations) const;
+
+    void check_invariants() const;
+
+    void unfreeze();
+
+    void unfreeze(FoundationType const & a_foundation);
+
+    void generate_triggered_check(ACE_INET_Addr const & a_local_address, ACE_INET_Addr const & a_remote_address,
+                                  uint32_t a_priority,
+                                  bool a_use_candidate);
+
+    void success_response(ACE_INET_Addr const & a_local_address,
+                          ACE_INET_Addr const & a_remote_address,
+                          STUN::Message const & a_message);
+
+    void error_response(ACE_INET_Addr const & a_local_address,
+                        ACE_INET_Addr const & a_remote_address,
+                        STUN::Message const & a_message);
+
+    void add_guid(GuidPair const & a_guid_pair);
+
+    void remove_guid(GuidPair const & a_guid_pair);
+
+    void add_guids(GuidSetType const & a_guids);
+
+    void remove_guids();
+
+    GuidSetType guids() const { return m_guids; }
+
+    ACE_INET_Addr selected_address() const;
+
+    AgentInfo const & original_remote_agent_info() const { return m_original_remote_agent_info; }
+
+    void set_remote_password(std::string const & a_password) {
+      m_remote_agent_info.password = a_password;
+      m_original_remote_agent_info.password = a_password;
+    }
+
+    void indication();
+
+  private:
+    bool m_scheduled_for_destruction;
+    EndpointManager * const m_endpoint_manager;
+    GuidSetType m_guids;
+    AgentInfo m_local_agent_info;
+    AgentInfo m_remote_agent_info;
+    AgentInfo m_original_remote_agent_info;
+    bool const m_local_is_controlling;
+    ACE_UINT64 const m_ice_tie_breaker;
+
+    typedef std::list<CandidatePair> CandidatePairsType;
+    CandidatePairsType m_frozen;
+    CandidatePairsType m_waiting;
+    CandidatePairsType m_in_progress;
+    CandidatePairsType m_succeeded;
+    CandidatePairsType m_failed;
+    // The triggered check queue is a subset of waiting.
+    CandidatePairsType m_triggered_check_queue;
+    // The valid list is a subset of succeeded.
+    CandidatePairsType m_valid_list;
+    // These are iterators into m_valid_list.
+    CandidatePairsType::const_iterator m_nominating;
+    CandidatePairsType::const_iterator m_nominated;
+    ACE_Time_Value m_nominated_is_live;
+    ACE_Time_Value m_last_indication;
+    ACE_Time_Value m_check_interval;
+    ACE_Time_Value m_max_check_interval;
+    typedef std::list<ConnectivityCheck> ConnectivityChecksType;
+    ConnectivityChecksType m_connectivity_checks;
+
+    ~Checklist() {}
+
+    void reset();
+
+    void generate_candidate_pairs();
+
+    void fix_foundations();
+
+    void add_valid_pair(CandidatePair const & a_valid_pair);
+
+    bool get_local_candidate(ACE_INET_Addr const & a_address, Candidate & a_candidate);
+
+    bool get_remote_candidate(ACE_INET_Addr const & a_address, Candidate & a_candidate);
+
+    bool is_succeeded(CandidatePair const & a_candidate_pair) const {
+      return std::find(m_succeeded.begin(), m_succeeded.end(), a_candidate_pair) != m_succeeded.end();
+    }
+
+    bool is_in_progress(CandidatePair const & a_candidate_pair) const {
+      return std::find(m_in_progress.begin(), m_in_progress.end(), a_candidate_pair) != m_in_progress.end();
+    }
+
+    void add_triggered_check(CandidatePair const & a_candidate_pair);
+
+    void remove_from_in_progress(CandidatePair const & a_candidate_pair);
+
+    void succeeded(ConnectivityCheck const & a_connectivity_check);
+
+    void failed(ConnectivityCheck const & a_connectivity_check);
+
+    // Measure of now many checks are left.
+    size_t size() const {
+      return m_frozen.size() + m_waiting.size() + m_in_progress.size();
+    }
+
+    void do_next_check(ACE_Time_Value const & a_now);
+
+    void execute(ACE_Time_Value const & a_now);
+  };
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_CHECKLIST_H */

--- a/dds/DCPS/ICE/EndpointManager.cpp
+++ b/dds/DCPS/ICE/EndpointManager.cpp
@@ -1,0 +1,706 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "EndpointManager.h"
+
+#include <ace/Reverse_Lock_T.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+
+#include "Checklist.h"
+
+#include <iostream>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  std::string stringify(unsigned char x[16]) {
+    char retval[32];
+    for (size_t idx = 0; idx != 16; ++idx) {
+      retval[2 * idx] = (x[idx] & 0x0F) + 97;
+      retval[2 * idx + 1] = ((x[idx] & 0xF0) >> 4) + 97;
+    }
+    return std::string(retval, 32);
+  }
+
+  EndpointManager::EndpointManager(AgentImpl * a_agent_impl, Endpoint * a_endpoint) :
+    agent_impl(a_agent_impl),
+    endpoint(a_endpoint),
+    m_scheduled_for_destruction(false),
+    m_requesting(true),
+    m_send_count(0),
+    m_server_reflexive_task(this),
+    m_change_password_task(this) {
+
+    // Set the type.
+    m_agent_info.type = FULL;
+
+    int rc =  RAND_bytes(reinterpret_cast<unsigned char*>(&m_ice_tie_breaker), sizeof(m_ice_tie_breaker));
+    if (rc != 1) {
+      unsigned long err = ERR_get_error();
+      char msg[256] = { 0 };
+      ERR_error_string_n(err, msg, sizeof(msg));
+
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) EndpointManager::EndpointManager: ERROR '%C' returned by RAND_bytes(...)\n"),
+                 msg));
+    }
+
+    change_username();
+    set_host_addresses(endpoint->host_addresses());
+  }
+
+  void EndpointManager::start_ice(DCPS::RepoId const & a_local_guid,
+                                  DCPS::RepoId const & a_remote_guid,
+                                  AgentInfo const & a_remote_agent_info) {
+    // Check for username collision.
+    if (a_remote_agent_info.username == m_agent_info.username) {
+      change_username();
+    }
+
+    GuidPair guidp(a_local_guid, a_remote_guid);
+
+    // Try to find by guid.
+    Checklist * guid_checklist = 0;
+    {
+      GuidPairToChecklistType::const_iterator pos = m_guid_pair_to_checklist.find(guidp);
+      if (pos != m_guid_pair_to_checklist.end()) {
+        guid_checklist = pos->second;
+      }
+    }
+
+    // Try to find by username.
+    Checklist * username_checklist = 0;
+    {
+      UsernameToChecklistType::const_iterator pos = m_username_to_checklist.find(a_remote_agent_info.username);
+      if (pos != m_username_to_checklist.end()) {
+        username_checklist = pos->second;
+      } else {
+        std::cout << "New checklist for " << a_remote_agent_info.username << std::endl;
+        username_checklist = create_checklist(a_remote_agent_info);
+      }
+    }
+
+    if (guid_checklist != username_checklist) {
+      if (guid_checklist != 0) {
+        guid_checklist->remove_guid(guidp);
+      }
+      username_checklist->add_guid(guidp);
+    }
+
+    AgentInfo old_remote_agent_info = username_checklist->original_remote_agent_info();
+    if (old_remote_agent_info == a_remote_agent_info) {
+      // No change.
+      return;
+    }
+
+    old_remote_agent_info.password = a_remote_agent_info.password;
+    if (old_remote_agent_info == a_remote_agent_info) {
+      // Password change.
+      username_checklist->set_remote_password(a_remote_agent_info.password);
+      return;
+    }
+
+    // The remote agent changed its info without changing its username.
+    GuidSetType const guids = username_checklist->guids();
+    username_checklist->remove_guids();
+    std::cout << "Modified checklist for " << a_remote_agent_info.username << std::endl;
+    username_checklist = create_checklist(a_remote_agent_info);
+    username_checklist->add_guids(guids);
+  }
+
+  void EndpointManager::stop_ice(DCPS::RepoId const & a_local_guid,
+                                 DCPS::RepoId const & a_remote_guid) {
+    GuidPair guidp(a_local_guid, a_remote_guid);
+
+    GuidPairToChecklistType::const_iterator pos = m_guid_pair_to_checklist.find(guidp);
+    if (pos != m_guid_pair_to_checklist.end()) {
+      Checklist * guid_checklist = pos->second;
+      guid_checklist->remove_guid(guidp);
+    }
+  }
+
+  ACE_INET_Addr EndpointManager::get_address(DCPS::RepoId const & a_local_guid,
+                                             DCPS::RepoId const & a_remote_guid) const {
+    GuidPair guidp(a_local_guid, a_remote_guid);
+    GuidPairToChecklistType::const_iterator pos = m_guid_pair_to_checklist.find(guidp);
+    if (pos != m_guid_pair_to_checklist.end()) {
+      return pos->second->selected_address();
+    }
+
+    return ACE_INET_Addr();
+  }
+
+
+  void EndpointManager::receive(ACE_INET_Addr const & a_local_address,
+                                ACE_INET_Addr const & a_remote_address,
+                                STUN::Message const & a_message) {
+    switch (a_message.class_) {
+    case STUN::REQUEST:
+      request(a_local_address, a_remote_address, a_message);
+      return;
+    case STUN::INDICATION:
+      indication(a_message);
+      return;
+    case STUN::SUCCESS_RESPONSE:
+      success_response(a_local_address, a_remote_address, a_message);
+      return;
+    case STUN::ERROR_RESPONSE:
+      error_response(a_local_address, a_remote_address, a_message);
+      return;
+    }
+
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::receive: WARNING Unknown ICE message class %d\n"), a_message.class_));
+  }
+
+  void EndpointManager::change_username() {
+    // Generate the username.
+    unsigned char username[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    int rc = RAND_bytes(username, sizeof(username));
+    if (rc != 1) {
+      unsigned long err = ERR_get_error();
+      char msg[256] = { 0 };
+      ERR_error_string_n(err, msg, sizeof(msg));
+
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) EndpointManager::EndpointManager: ERROR '%C' returned by RAND_bytes(...)\n"),
+                 msg));
+    }
+    m_agent_info.username = stringify(username);
+    change_password(false);
+  }
+
+  void EndpointManager::change_password(bool password_only) {
+    std::cout << "Changing password" << std::endl;
+    unsigned char password[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    int rc = RAND_bytes(password, sizeof(password));
+    if (rc != 1) {
+      unsigned long err = ERR_get_error();
+      char msg[256] = { 0 };
+      ERR_error_string_n(err, msg, sizeof(msg));
+
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) EndpointManager::change_password: ERROR '%C' returned by RAND_bytes(...)\n"),
+                 msg));
+    }
+    m_agent_info.password = stringify(password);
+    regenerate_agent_info(password_only);
+  }
+
+  void EndpointManager::set_host_addresses(AddressListType const & a_host_addresses) {
+    // Section IETF RFC 8445 5.1.1.1
+    // TODO(jrw972):  Handle IPv6.
+    AddressListType host_addresses;
+    for (AddressListType::const_iterator pos = a_host_addresses.begin(), limit = a_host_addresses.end();
+         pos != limit; ++pos) {
+      if (pos->is_loopback()) {
+        continue;
+      }
+      host_addresses.push_back(*pos);
+    }
+
+    if (m_host_addresses != host_addresses) {
+      m_host_addresses = host_addresses;
+      regenerate_agent_info(false);
+    }
+  }
+
+  void EndpointManager::set_server_reflexive_address(ACE_INET_Addr const & a_server_reflexive_address,
+                                                     ACE_INET_Addr const & a_stun_server_address) {
+    if (m_server_reflexive_address != a_server_reflexive_address ||
+        m_stun_server_address != a_stun_server_address) {
+      m_server_reflexive_address = a_server_reflexive_address;
+      m_stun_server_address = a_stun_server_address;
+      regenerate_agent_info(false);
+    }
+  }
+
+  void EndpointManager::regenerate_agent_info(bool password_only) {
+    if (!password_only) {
+      // Populate candidates.
+      m_agent_info.candidates.clear();
+      for (AddressListType::const_iterator pos = m_host_addresses.begin(), limit = m_host_addresses.end(); pos != limit; ++pos) {
+        m_agent_info.candidates.push_back(make_host_candidate(*pos));
+        if (m_server_reflexive_address != ACE_INET_Addr() &&
+            m_stun_server_address != ACE_INET_Addr()) {
+          m_agent_info.candidates.push_back(make_server_reflexive_candidate(m_server_reflexive_address, *pos, m_stun_server_address));
+        }
+      }
+
+      // Eliminate duplicates.
+      std::sort(m_agent_info.candidates.begin (), m_agent_info.candidates.end (), candidates_sorted);
+      AgentInfo::CandidatesType::iterator last = std::unique(m_agent_info.candidates.begin (), m_agent_info.candidates.end (), candidates_equal);
+      m_agent_info.candidates.erase(last, m_agent_info.candidates.end());
+
+      // Start over.
+      UsernameToChecklistType old_checklists = m_username_to_checklist;
+      for (UsernameToChecklistType::const_iterator pos = old_checklists.begin(),
+             limit = old_checklists.end();
+           pos != limit; ++pos) {
+        Checklist * old_checklist = pos->second;
+        AgentInfo const remote_agent_info = old_checklist->original_remote_agent_info();
+        GuidSetType const guids = old_checklist->guids();
+        old_checklist->remove_guids();
+        std::cout << "Starting over for " << remote_agent_info.username << std::endl;
+        Checklist * new_checklist = create_checklist(remote_agent_info);
+        new_checklist->add_guids(guids);
+      }
+    }
+
+    {
+      // Propagate changed agent info.
+
+      // Make a copy.
+      AgentInfoListenersType agent_info_listeners = m_agent_info_listeners;
+      AgentInfo agent_info = m_agent_info;
+
+      // Release the lock.
+      ACE_Reverse_Lock<ACE_Recursive_Thread_Mutex> rev_lock(agent_impl->mutex);
+      ACE_GUARD(ACE_Reverse_Lock<ACE_Recursive_Thread_Mutex>, rev_guard, rev_lock);
+
+      for (AgentInfoListenersType::const_iterator pos = agent_info_listeners.begin(),
+             limit =  agent_info_listeners.end(); pos != limit; ++pos) {
+        pos->second->update_agent_info(pos->first, agent_info);
+      }
+    }
+  }
+
+  void EndpointManager::server_reflexive_task(ACE_Time_Value const & a_now) {
+    // Request and maintain a server-reflexive address.
+    m_next_stun_server_address = endpoint->stun_server_address();
+    if (m_next_stun_server_address != ACE_INET_Addr()) {
+      m_binding_request = STUN::Message();
+      m_binding_request.class_ = m_requesting ? STUN::REQUEST : STUN::INDICATION;
+      m_binding_request.method = STUN::BINDING;
+      m_binding_request.generate_transaction_id();
+      m_binding_request.append_attribute(STUN::make_fingerprint());
+
+      endpoint->send(m_next_stun_server_address, m_binding_request);
+      if (!m_requesting && m_send_count == agent_impl->get_configuration().server_reflexive_indication_count() - 1) {
+        m_requesting = true;
+      }
+      m_send_count = (m_send_count + 1) % agent_impl->get_configuration().server_reflexive_indication_count();
+    } else {
+      m_requesting = true;
+      m_send_count = 0;
+    }
+
+    // Remove expired deferred checks.
+    for (DeferredTriggeredChecksType::iterator pos = m_deferred_triggered_checks.begin(),
+           limit = m_deferred_triggered_checks.end(); pos != limit;) {
+      DeferredTriggeredCheckListType & list = pos->second;
+      while (!list.empty() && list.front().expiration_date < a_now) {
+        list.pop_front();
+      }
+      if (list.empty()) {
+        m_deferred_triggered_checks.erase(pos++);
+      } else {
+        pos++;
+      }
+    }
+
+    // Repopulate the host addresses.
+    set_host_addresses(endpoint->host_addresses());
+  }
+
+  bool EndpointManager::success_response(STUN::Message const & a_message) {
+    if (a_message.transaction_id != m_binding_request.transaction_id) {
+      return false;
+    }
+
+    std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+    if (!unknown_attributes.empty()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::success_response: WARNING Unknown comprehension required attributes\n")));
+      return true;
+    }
+
+    ACE_INET_Addr server_reflexive_address;
+    if (a_message.get_mapped_address(server_reflexive_address)) {
+      set_server_reflexive_address(server_reflexive_address, m_next_stun_server_address);
+      m_requesting = false;
+      m_send_count = 0;
+    } else {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::success_response: WARNING No (XOR)_MAPPED_ADDRESS attribute\n")));
+      set_server_reflexive_address(ACE_INET_Addr(), ACE_INET_Addr());
+      m_requesting = true;
+      m_send_count = 0;
+    }
+    return true;
+  }
+
+  bool EndpointManager::error_response(STUN::Message const & a_message) {
+    if (a_message.transaction_id != m_binding_request.transaction_id) {
+      return false;
+    }
+
+    if (a_message.has_error_code()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING STUN error response code=%d reason=%s\n"), a_message.get_error_code(), a_message.get_error_reason().c_str()));
+      if (a_message.get_error_code() == 420 && a_message.has_unknown_attributes()) {
+        std::vector<STUN::AttributeType> unknown_attributes = a_message.get_unknown_attributes();
+        for (std::vector<STUN::AttributeType>::const_iterator pos = unknown_attributes.begin(),
+               limit = unknown_attributes.end(); pos != limit; ++pos) {
+          ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING Unknown STUN attribute %d\n"), *pos));
+        }
+      }
+    } else {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING STUN error response (no code)\n")));
+    }
+
+    return true;
+  }
+
+  Checklist * EndpointManager::create_checklist(AgentInfo const & remote_agent_info) {
+    Checklist* checklist = new Checklist(this, m_agent_info, remote_agent_info, m_ice_tie_breaker);
+    // Add the deferred triggered first in case there was a nominating check.
+    DeferredTriggeredChecksType::iterator pos = m_deferred_triggered_checks.find(remote_agent_info.username);
+    if (pos != m_deferred_triggered_checks.end()) {
+      const DeferredTriggeredCheckListType& list = pos->second;
+      for (DeferredTriggeredCheckListType::const_iterator pos = list.begin(), limit = list.end(); pos != limit; ++pos) {
+        checklist->generate_triggered_check(pos->local_address, pos->remote_address, pos->priority, pos->use_candidate);
+      }
+      m_deferred_triggered_checks.erase(pos);
+    }
+    checklist->unfreeze();
+
+    return checklist;
+  }
+
+  STUN::Message EndpointManager::make_unknown_attributes_error_response(STUN::Message const & a_message,
+                                                                        std::vector<STUN::AttributeType> const & a_unknown_attributes) {
+    STUN::Message response;
+    response.class_ = STUN::ERROR_RESPONSE;
+    response.method = a_message.method;
+    memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+    response.append_attribute(STUN::make_error_code(420, "Unknown Attributes"));
+    response.append_attribute(STUN::make_unknown_attributes(a_unknown_attributes));
+    response.append_attribute(STUN::make_message_integrity());
+    response.password = m_agent_info.password;
+    response.append_attribute(STUN::make_fingerprint());
+    return response;
+  }
+
+  STUN::Message EndpointManager::make_bad_request_error_response(STUN::Message const & a_message,
+                                                                 std::string const & a_reason) {
+    STUN::Message response;
+    response.class_ = STUN::ERROR_RESPONSE;
+    response.method = a_message.method;
+    memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+    response.append_attribute(STUN::make_error_code(400, a_reason));
+    response.append_attribute(STUN::make_message_integrity());
+    response.password = m_agent_info.password;
+    response.append_attribute(STUN::make_fingerprint());
+    return response;
+  }
+
+  STUN::Message EndpointManager::make_unauthorized_error_response(STUN::Message const & a_message) {
+    STUN::Message response;
+    response.class_ = STUN::ERROR_RESPONSE;
+    response.method = a_message.method;
+    memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+    response.append_attribute(STUN::make_error_code(401, "Unauthorized"));
+    response.append_attribute(STUN::make_message_integrity());
+    response.password = m_agent_info.password;
+    response.append_attribute(STUN::make_fingerprint());
+    return response;
+  }
+
+  // STUN Message processing.
+  void EndpointManager::request(ACE_INET_Addr const & a_local_address,
+                                ACE_INET_Addr const & a_remote_address,
+                                STUN::Message const & a_message) {
+    std::string username;
+    if (!a_message.get_username(username)) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No USERNAME attribute\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: USERNAME must be present"));
+      return;
+    }
+    if (!a_message.has_message_integrity()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No MESSAGE_INTEGRITY attribute\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: MESSAGE_INTEGRITY must be present"));
+      return;
+    }
+
+    size_t idx = username.find(':');
+    if (idx == std::string::npos) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING USERNAME does not contain a colon\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: USERNAME must be colon-separated"));
+      return;
+    }
+
+    if (username.substr(0, idx) != m_agent_info.username) {
+      // We expect this to happen.
+      endpoint->send(a_remote_address,
+                     make_unauthorized_error_response(a_message));
+      return;
+    }
+
+    const std::string remote_username = username.substr(++idx);
+
+    // Check the message_integrity.
+    if (!a_message.verify_message_integrity(m_agent_info.password)) {
+      // We expect this to happen.
+      endpoint->send(a_remote_address,
+                     make_unauthorized_error_response(a_message));
+      return;
+    }
+
+    std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+    if (!unknown_attributes.empty()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING Unknown comprehension required attributes\n")));
+      endpoint->send(a_remote_address,
+                     make_unknown_attributes_error_response(a_message, unknown_attributes));
+      return;
+    }
+
+    if (!a_message.has_fingerprint()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No FINGERPRINT attribute\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: FINGERPRINT must be present"));
+      return;
+    }
+
+    if (!a_message.has_ice_controlled() && !a_message.has_ice_controlling()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No ICE_CONTROLLED/ICE_CONTROLLING attribute\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: Either ICE_CONTROLLED or ICE_CONTROLLING must be present"));
+      return;
+    }
+
+    bool use_candidate = a_message.has_use_candidate();
+    if (use_candidate && a_message.has_ice_controlled()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING USE_CANDIDATE without ICE_CONTROLLED\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: USE_CANDIDATE can only be present when ICE_CONTROLLED is present"));
+      return;
+    }
+
+    uint32_t priority;
+    if (!a_message.get_priority(priority)) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No PRIORITY attribute\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: PRIORITY must be present"));
+      return;
+    }
+
+    switch (a_message.method) {
+    case STUN::BINDING:
+      {
+        // 7.3
+        STUN::Message response;
+        response.class_ = STUN::SUCCESS_RESPONSE;
+        response.method = STUN::BINDING;
+        memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+        response.append_attribute(STUN::make_mapped_address(a_remote_address));
+        response.append_attribute(STUN::make_xor_mapped_address(a_remote_address));
+        response.append_attribute(STUN::make_message_integrity());
+        response.password = m_agent_info.password;
+        response.append_attribute(STUN::make_fingerprint());
+        endpoint->send(a_remote_address, response);
+
+        // 7.3.1.3
+        UsernameToChecklistType::const_iterator pos = m_username_to_checklist.find(remote_username);
+        if (pos != m_username_to_checklist.end()) {
+          // We have a checklist.
+          Checklist* checklist = pos->second;
+          checklist->generate_triggered_check(a_local_address, a_remote_address, priority, use_candidate);
+        } else {
+          std::pair<DeferredTriggeredChecksType::iterator, bool> x = m_deferred_triggered_checks.insert(std::make_pair(remote_username, DeferredTriggeredCheckListType()));
+          x.first->second.push_back(DeferredTriggeredCheck(a_local_address, a_remote_address, priority, use_candidate, ACE_Time_Value().now() + agent_impl->get_configuration().deferred_triggered_check_ttl()));
+        }
+      }
+      break;
+    default:
+      // Unknown method.  Stop processing.
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING Unknown ICE method\n")));
+      endpoint->send(a_remote_address,
+                     make_bad_request_error_response(a_message, "Bad Request: Unknown method"));
+      break;
+    }
+  }
+
+  void EndpointManager::indication(STUN::Message const & a_message) {
+    std::string username;
+    if (!a_message.get_username(username)) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING No USERNAME attribute\n")));
+      return;
+    }
+    if (!a_message.has_message_integrity()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING No MESSAGE_INTEGRITY attribute\n")));
+      return;
+    }
+
+    size_t idx = username.find(':');
+    if (idx == std::string::npos) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING USERNAME does not contain a colon\n")));
+      return;
+    }
+
+    if (username.substr(0, idx) != m_agent_info.username) {
+      // We expect this to happen.
+      return;
+    }
+
+    const std::string remote_username = username.substr(++idx);
+
+    // Check the message_integrity.
+    if (!a_message.verify_message_integrity(m_agent_info.password)) {
+      // We expect this to happen.
+      return;
+    }
+
+    std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+    if (!unknown_attributes.empty()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING Unknown comprehension required attributes\n")));
+      return;
+    }
+
+    if (!a_message.has_fingerprint()) {
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING No FINGERPRINT attribute\n")));
+      return;
+    }
+
+    switch (a_message.method) {
+    case STUN::BINDING:
+      {
+        // Section 11
+        UsernameToChecklistType::const_iterator pos = m_username_to_checklist.find(remote_username);
+        if (pos != m_username_to_checklist.end()) {
+          // We have a checklist.
+          pos->second->indication();
+        }
+      }
+      break;
+    default:
+      // Unknown method.  Stop processing.
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING Unknown ICE method\n")));
+      break;
+    }
+  }
+
+  void EndpointManager::success_response(ACE_INET_Addr const & a_local_address,
+                                         ACE_INET_Addr const & a_remote_address,
+                                         STUN::Message const & a_message) {
+    switch (a_message.method) {
+    case STUN::BINDING:
+      {
+        if (success_response(a_message)) {
+          return;
+        }
+
+        TransactionIdToChecklistType::const_iterator pos = m_transaction_id_to_checklist.find(a_message.transaction_id);
+        if (pos == m_transaction_id_to_checklist.end()) {
+          // Probably a check that got cancelled.
+          return;
+        }
+
+        // Checklist is responsible for updating the map.
+        // Checklist also checks for required parameters.
+        pos->second->success_response(a_local_address, a_remote_address, a_message);
+      }
+      break;
+    default:
+      // Unknown method.  Stop processing.
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::success_response: WARNING Unknown ICE method\n")));
+      break;
+    }
+  }
+
+  void EndpointManager::error_response(ACE_INET_Addr const & a_local_address,
+                                       ACE_INET_Addr const & a_remote_address,
+                                       STUN::Message const & a_message) {
+    switch (a_message.method) {
+    case STUN::BINDING:
+      {
+        if (error_response(a_message)) {
+          return;
+        }
+
+        TransactionIdToChecklistType::const_iterator pos = m_transaction_id_to_checklist.find(a_message.transaction_id);
+        if (pos == m_transaction_id_to_checklist.end()) {
+          // Probably a check that got cancelled.
+          return;
+        }
+
+        // Checklist is responsible for updating the map.
+        // Checklist also checks for required parameters.
+        pos->second->error_response(a_local_address, a_remote_address, a_message);
+      }
+      break;
+    default:
+      // Unknown method.  Stop processing.
+      ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING Unknown ICE method\n")));
+      break;
+    }
+  }
+
+  void EndpointManager::compute_active_foundations(ActiveFoundationSet & a_active_foundations) const {
+    for (UsernameToChecklistType::const_iterator pos = m_username_to_checklist.begin(),
+           limit = m_username_to_checklist.end(); pos != limit; ++pos) {
+      const Checklist* checklist = pos->second;
+      checklist->compute_active_foundations(a_active_foundations);
+    }
+  }
+
+  void EndpointManager::check_invariants() const {
+    for (UsernameToChecklistType::const_iterator pos = m_username_to_checklist.begin(),
+           limit = m_username_to_checklist.end(); pos != limit; ++pos) {
+      const Checklist* checklist = pos->second;
+      checklist->check_invariants();
+    }
+  }
+
+  void EndpointManager::schedule_for_destruction() {
+    m_scheduled_for_destruction = true;
+    UsernameToChecklistType old_checklists = m_username_to_checklist;
+    for (UsernameToChecklistType::const_iterator pos = old_checklists.begin(),
+           limit = old_checklists.end(); pos != limit; ++pos) {
+      pos->second->remove_guids();
+    }
+  }
+
+  void EndpointManager::unfreeze(FoundationType const & a_foundation) {
+    for (UsernameToChecklistType::const_iterator pos = m_username_to_checklist.begin(),
+           limit = m_username_to_checklist.end(); pos != limit; ++pos) {
+      pos->second->unfreeze(a_foundation);
+    }
+  }
+
+  EndpointManager::ServerReflexiveTask::ServerReflexiveTask(EndpointManager * a_endpoint_manager)
+    : Task(a_endpoint_manager->agent_impl),
+      endpoint_manager(a_endpoint_manager) {
+    enqueue(ACE_Time_Value().now());
+  }
+
+  void EndpointManager::ServerReflexiveTask::execute(ACE_Time_Value const & a_now) {
+    if (endpoint_manager->m_scheduled_for_destruction) {
+      delete endpoint_manager;
+      return;
+    }
+    endpoint_manager->server_reflexive_task(a_now);
+    enqueue(a_now + endpoint_manager->agent_impl->get_configuration().server_reflexive_address_period());
+  }
+
+  EndpointManager::ChangePasswordTask::ChangePasswordTask(EndpointManager * a_endpoint_manager)
+    : Task(a_endpoint_manager->agent_impl),
+      endpoint_manager(a_endpoint_manager) {
+    enqueue(ACE_Time_Value().now() + endpoint_manager->agent_impl->get_configuration().change_password_period());
+  }
+
+  void EndpointManager::ChangePasswordTask::execute(ACE_Time_Value const & a_now) {
+    endpoint_manager->change_password(true);
+    enqueue(a_now + endpoint_manager->agent_impl->get_configuration().change_password_period());
+  }
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ICE/EndpointManager.h
+++ b/dds/DCPS/ICE/EndpointManager.h
@@ -1,0 +1,221 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_ENDPOINT_MANAGER_H
+#define OPENDDS_RTPS_ICE_ENDPOINT_MANAGER_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include "dds/Versioned_Namespace.h"
+#include <ace/INET_Addr.h>
+
+#include "Ice.h"
+#include "Task.h"
+#include "Checklist.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  class AgentImpl;
+  struct Checklist;
+
+  struct DeferredTriggeredCheck {
+    ACE_INET_Addr local_address;
+    ACE_INET_Addr remote_address;
+    uint32_t priority;
+    bool use_candidate;
+    ACE_Time_Value expiration_date;
+
+    DeferredTriggeredCheck(ACE_INET_Addr const & a_local_address,
+                           ACE_INET_Addr const & a_remote_address,
+                           uint32_t a_priority,
+                           bool a_use_candidate,
+                           ACE_Time_Value const & a_expiration_date)
+      : local_address(a_local_address)
+      , remote_address(a_remote_address)
+      , priority(a_priority)
+      , use_candidate(a_use_candidate)
+      , expiration_date(a_expiration_date)
+    {}
+  };
+
+  struct EndpointManager {
+    AgentImpl * const agent_impl;
+    Endpoint * const endpoint;
+
+    EndpointManager(AgentImpl * a_agent_impl, Endpoint * a_endpoint);
+
+    AgentInfo const & agent_info() const { return m_agent_info; }
+
+    void add_agent_info_listener(DCPS::RepoId const & a_local_guid,
+                                 AgentInfoListener * a_agent_info_listener) {
+      m_agent_info_listeners[a_local_guid] = a_agent_info_listener;
+    }
+
+    void remove_agent_info_listener(DCPS::RepoId const & a_local_guid) {
+      m_agent_info_listeners.erase(a_local_guid);
+    }
+
+    void start_ice(DCPS::RepoId const & a_local_guid,
+                   DCPS::RepoId const & a_remote_guid,
+                   AgentInfo const & a_remote_agent_info);
+
+    void stop_ice(DCPS::RepoId const & local_guid,
+                  DCPS::RepoId const & remote_guid);
+
+    ACE_INET_Addr get_address(DCPS::RepoId const & a_local_guid,
+                              DCPS::RepoId const & a_remote_guid) const;
+
+    void receive(ACE_INET_Addr const & a_local_address,
+                 ACE_INET_Addr const & a_remote_address,
+                 STUN::Message const & a_message);
+
+    void set_responsible_checklist(STUN::TransactionId const & a_transaction_id, Checklist * a_checklist) {
+      TransactionIdToChecklistType::const_iterator pos = m_transaction_id_to_checklist.find(a_transaction_id);
+      assert(pos == m_transaction_id_to_checklist.end());
+      m_transaction_id_to_checklist[a_transaction_id] = a_checklist;
+    }
+
+    void unset_responsible_checklist(STUN::TransactionId const & a_transaction_id, Checklist * a_checklist) {
+      TransactionIdToChecklistType::const_iterator pos = m_transaction_id_to_checklist.find(a_transaction_id);
+      assert(pos != m_transaction_id_to_checklist.end());
+      assert(pos->second == a_checklist);
+      m_transaction_id_to_checklist.erase(pos);
+    }
+
+    void set_responsible_checklist(GuidPair const & a_guid_pair, Checklist * a_checklist) {
+      GuidPairToChecklistType::const_iterator pos = m_guid_pair_to_checklist.find(a_guid_pair);
+      assert(pos == m_guid_pair_to_checklist.end());
+      m_guid_pair_to_checklist[a_guid_pair] = a_checklist;
+    }
+
+    void unset_responsible_checklist(GuidPair const & a_guid_pair, Checklist * a_checklist) {
+      GuidPairToChecklistType::const_iterator pos = m_guid_pair_to_checklist.find(a_guid_pair);
+      assert(pos != m_guid_pair_to_checklist.end());
+      assert(pos->second == a_checklist);
+      m_guid_pair_to_checklist.erase(pos);
+    }
+
+    void set_responsible_checklist(std::string const & a_username, Checklist * a_checklist) {
+      UsernameToChecklistType::const_iterator pos = m_username_to_checklist.find(a_username);
+      assert(pos == m_username_to_checklist.end());
+      m_username_to_checklist[a_username] = a_checklist;
+    }
+
+    void unset_responsible_checklist(std::string const & a_username, Checklist * a_checklist) {
+      UsernameToChecklistType::const_iterator pos = m_username_to_checklist.find(a_username);
+      assert(pos != m_username_to_checklist.end());
+      assert(pos->second == a_checklist);
+      m_username_to_checklist.erase(pos);
+    }
+
+    void unfreeze(FoundationType const & a_foundation);
+
+    void compute_active_foundations(ActiveFoundationSet & a_active_foundations) const;
+
+    void check_invariants() const;
+
+    void schedule_for_destruction();
+
+  private:
+    bool m_scheduled_for_destruction;
+    AddressListType m_host_addresses;          // Cached list of host addresses.
+    ACE_INET_Addr m_server_reflexive_address;  // Server-reflexive address (from STUN server).
+    ACE_INET_Addr m_stun_server_address;       // Address of the STUN server.
+    ACE_UINT64 m_ice_tie_breaker;
+    AgentInfo m_agent_info;
+
+    // State variables for getting and maintaining the server reflexive address.
+    bool m_requesting;
+    size_t m_send_count;
+    ACE_INET_Addr m_next_stun_server_address;
+    STUN::Message m_binding_request;       // Binding request sent to STUN server.
+
+    typedef std::deque<DeferredTriggeredCheck> DeferredTriggeredCheckListType;
+    typedef std::map<std::string, DeferredTriggeredCheckListType> DeferredTriggeredChecksType;
+    DeferredTriggeredChecksType m_deferred_triggered_checks;
+
+    // Managed by checklists.
+    typedef std::map<std::string, Checklist*> UsernameToChecklistType;
+    UsernameToChecklistType m_username_to_checklist;
+
+    // Managed by checklists.
+    typedef std::map<STUN::TransactionId, Checklist*> TransactionIdToChecklistType;
+    TransactionIdToChecklistType m_transaction_id_to_checklist;
+
+    // Managed by checklists.
+    typedef std::map<GuidPair, Checklist*> GuidPairToChecklistType;
+    GuidPairToChecklistType m_guid_pair_to_checklist;
+
+    typedef std::map<DCPS::RepoId, AgentInfoListener *, DCPS::GUID_tKeyLessThan> AgentInfoListenersType;
+    AgentInfoListenersType m_agent_info_listeners;
+
+    void change_username();
+
+    void change_password(bool password_only);
+
+    void set_host_addresses(AddressListType const & a_host_addresses);
+
+    void set_server_reflexive_address(ACE_INET_Addr const & a_server_reflexive_address,
+                                      ACE_INET_Addr const & a_stun_server_address);
+
+    void regenerate_agent_info(bool password_only);
+
+    void server_reflexive_task(ACE_Time_Value const & a_now);
+
+    bool success_response(STUN::Message const & a_message);
+
+    bool error_response(STUN::Message const & a_message);
+
+    Checklist* create_checklist(AgentInfo const & a_remote_agent_info);
+
+    // STUN Message processing.
+    STUN::Message make_unknown_attributes_error_response(STUN::Message const & a_message,
+                                                         std::vector<STUN::AttributeType> const & a_unknown_attributes);
+
+    STUN::Message make_bad_request_error_response(STUN::Message const & a_message,
+                                                  std::string const & a_reason);
+
+    STUN::Message make_unauthorized_error_response(STUN::Message const & a_message);
+
+    void request(ACE_INET_Addr const & a_local_address,
+                 ACE_INET_Addr const & a_remote_address,
+                 STUN::Message const & a_message);
+
+    void indication(STUN::Message const & a_message);
+
+    void success_response(ACE_INET_Addr const & a_local_address,
+                          ACE_INET_Addr const & a_remote_address,
+                          STUN::Message const & a_message);
+
+    void error_response(ACE_INET_Addr const & a_local_address,
+                        ACE_INET_Addr const & a_remote_address,
+                        STUN::Message const & a_message);
+
+    struct ServerReflexiveTask : public Task {
+      EndpointManager * endpoint_manager;
+      ServerReflexiveTask(EndpointManager * a_endpoint_manager);
+      void execute(ACE_Time_Value const & a_now);
+    } m_server_reflexive_task;
+
+    struct ChangePasswordTask : public Task {
+      EndpointManager * endpoint_manager;
+      ChangePasswordTask(EndpointManager * a_endpoint_manager);
+      void execute(ACE_Time_Value const & a_now);
+    } m_change_password_task;
+  };
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_ENDPOINT_MANAGER_H */

--- a/dds/DCPS/ICE/Ice.cpp
+++ b/dds/DCPS/ICE/Ice.cpp
@@ -1,0 +1,126 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Ice.h"
+
+#include "AgentImpl.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  bool candidates_sorted(const Candidate& x, const Candidate& y) {
+    if (x.address != y.address) {
+      return x.address < y.address;
+    }
+    if (x.base != y.base) {
+      return x.base < y.base;
+    }
+    return x.priority > y.priority;
+  }
+
+  bool candidates_equal(const Candidate& x, const Candidate& y) {
+    return x.address == y.address && x.base == y.base;
+  }
+
+  Candidate make_host_candidate(const ACE_INET_Addr& address) {
+    Candidate candidate;
+    candidate.address = address;
+    candidate.foundation += "H" + std::string(address.get_host_addr()) + "U";
+    candidate.priority = (126 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+    candidate.type = HOST;
+    candidate.base = address;
+    return candidate;
+  }
+
+  Candidate make_server_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address) {
+    Candidate candidate;
+    candidate.address = address;
+    candidate.foundation += "S" + std::string(base.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+    candidate.priority = (100 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+    candidate.type = SERVER_REFLEXIVE;
+    candidate.base = base;
+    return candidate;
+  }
+
+  Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address, uint32_t priority) {
+    Candidate candidate;
+    candidate.address = address;
+    candidate.foundation += "P" + std::string(base.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+    candidate.priority = priority;
+    candidate.type = PEER_REFLEXIVE;
+    candidate.base = base;
+    return candidate;
+  }
+
+  Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, uint32_t priority, size_t q) {
+    Candidate candidate;
+    candidate.address = address;
+    candidate.foundation += "Q" + stringify(q) + "U";
+    candidate.priority = priority;
+    candidate.type = PEER_REFLEXIVE;
+    return candidate;
+  }
+
+  // Candidate make_relayed_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& server_address) {
+  //   Candidate candidate;
+  //   candidate.address = address;
+  //   candidate.foundation = "R" + std::string(address.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+  //   candidate.priority = (0 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+  //   candidate.type = RELAYED;
+  //   candidate.base = address;
+  //   return candidate;
+  // }
+
+  bool Candidate::operator==(const Candidate& other) const {
+    return
+      this->address == other.address &&
+      this->foundation == other.foundation &&
+      this->priority == other.priority &&
+      this->type == other.type;
+  }
+
+  Agent* Agent::instance() {
+    return ACE_Singleton<AgentImpl, ACE_SYNCH_MUTEX>::instance();
+  }
+
+  std::ostream& operator<<(std::ostream& stream, const ACE_INET_Addr& address) {
+    stream << address.get_host_addr() << ':' << address.get_port_number();
+    return stream;
+  }
+
+  std::ostream& operator<<(std::ostream& stream, const STUN::TransactionId& tid) {
+    for (size_t idx = 0; idx != 12; ++idx) {
+      stream << int(tid.data[idx]);
+    }
+    return stream;
+  }
+
+  std::ostream& operator<<(std::ostream& stream, const ICE::Candidate& candidate) {
+    stream << "address:    " << candidate.address << '\n'
+           << "foundation: " << candidate.foundation << '\n'
+           << "priority:   " << candidate.priority << '\n'
+           << "type:       " << candidate.type << '\n'
+           << "base:       " << candidate.base << '\n';
+    return stream;
+  }
+
+  std::ostream& operator<<(std::ostream& stream, const ICE::AgentInfo& agent_info) {
+    stream << "type:     " << agent_info.type     << '\n'
+           << "username: " << agent_info.username << '\n'
+           << "password: " << agent_info.password << '\n';
+    for (AgentInfo::const_iterator pos = agent_info.begin(), limit = agent_info.end(); pos != limit; ++pos) {
+      stream << *pos;
+    }
+    return stream;
+  }
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ICE/Ice.h
+++ b/dds/DCPS/ICE/Ice.h
@@ -1,0 +1,216 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_H
+#define OPENDDS_RTPS_ICE_H
+
+#include "ace/INET_Addr.h"
+#include "dds/DCPS/Serializer.h"
+#include "dds/DCPS/ICE/Stun.h"
+#include "dds/DdsDcpsInfoUtilsC.h"
+#include "dds/DCPS/GuidUtils.h"
+
+#include <cassert>
+#include <sstream>
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  template <typename T>
+  std::string stringify(T x) {
+    std::stringstream str;
+    str << x;
+    return str.str();
+  }
+
+  enum AgentType {
+    FULL = 0x0,
+    LITE = 0x1,
+  };
+
+  enum CandidateType {
+    HOST = 0x0,
+    SERVER_REFLEXIVE = 0x1,
+    PEER_REFLEXIVE = 0x2,
+    RELAYED = 0x3,
+  };
+
+  struct OpenDDS_Ice_Export Candidate {
+    ACE_INET_Addr address;
+    // Transport - UDP or TCP
+    std::string foundation;
+    // Component ID
+    uint32_t priority;
+    CandidateType type;
+    // Related Address and Port
+    // Extensibility Parameters
+
+    ACE_INET_Addr base;  // Not sent.
+
+    bool operator==(const Candidate& other) const;
+  };
+
+  bool candidates_sorted(const Candidate& x, const Candidate& y);
+  bool candidates_equal(const Candidate& x, const Candidate& y);
+
+  Candidate make_host_candidate(const ACE_INET_Addr& address);
+  Candidate make_server_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address);
+  Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address, uint32_t priority);
+  Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, uint32_t priority, size_t q);
+
+  struct AgentInfo {
+    typedef std::vector<Candidate> CandidatesType;
+    typedef CandidatesType::const_iterator const_iterator;
+
+    CandidatesType candidates;
+    AgentType type;
+    // Connectivity-Check Pacing Value
+    std::string username;
+    std::string password;
+    // Extensions
+
+    const_iterator begin() const { return candidates.begin(); }
+    const_iterator end() const { return candidates.end(); }
+    bool operator==(const AgentInfo& other) const {
+      return
+        this->username == other.username &&
+        this->password == other.password &&
+        this->type == other.type &&
+        this->candidates == other.candidates;
+    }
+    bool operator!=(const AgentInfo& other) const { return !(*this == other); }
+  };
+
+  typedef std::vector<ACE_INET_Addr> AddressListType;
+
+  class OpenDDS_Ice_Export Endpoint {
+  public:
+    virtual ~Endpoint() {}
+    virtual AddressListType host_addresses() const = 0;
+    virtual void send(const ACE_INET_Addr& address, const STUN::Message& message) = 0;
+    virtual ACE_INET_Addr stun_server_address() const = 0;
+  };
+
+  class OpenDDS_Ice_Export AgentInfoListener {
+  public:
+    virtual ~AgentInfoListener() {}
+    virtual void update_agent_info(DCPS::RepoId const & a_local_guid,
+                                   AgentInfo const & a_agent_info) = 0;
+  };
+
+  class OpenDDS_Ice_Export Configuration {
+  public:
+    Configuration() :
+      m_T_a(0, 50000),
+      m_connectivity_check_ttl(5 * 60),
+      m_checklist_period(5),
+      m_indication_period(15),
+      m_nominated_ttl(5 * 60),
+      m_server_reflexive_address_period(30),
+      m_server_reflexive_indication_count(10),
+      m_deferred_triggered_check_ttl(5 * 60),
+      m_change_password_period(5 * 60)
+    {}
+
+    void T_a(ACE_Time_Value const & x) { m_T_a = x; }
+    ACE_Time_Value T_a() const { return m_T_a; }
+
+    void connectivity_check_ttl(ACE_Time_Value const & x) { m_connectivity_check_ttl = x; }
+    ACE_Time_Value connectivity_check_ttl() const { return m_connectivity_check_ttl; }
+
+    void checklist_period(ACE_Time_Value const & x) { m_checklist_period = x; }
+    ACE_Time_Value checklist_period() const { return m_checklist_period; }
+
+    void indication_period(ACE_Time_Value const & x) { m_indication_period = x; }
+    ACE_Time_Value indication_period() const { return m_indication_period; }
+
+    void nominated_ttl(ACE_Time_Value const & x) { m_nominated_ttl = x; }
+    ACE_Time_Value nominated_ttl() const { return m_nominated_ttl; }
+
+    void server_reflexive_address_period(ACE_Time_Value const & x) { m_server_reflexive_address_period = x; }
+    ACE_Time_Value server_reflexive_address_period() const { return m_server_reflexive_address_period; }
+
+    void server_reflexive_indication_count(size_t x) { m_server_reflexive_indication_count = x; }
+    size_t server_reflexive_indication_count() const { return m_server_reflexive_indication_count; }
+
+    void deferred_triggered_check_ttl(ACE_Time_Value const & x) { m_deferred_triggered_check_ttl = x; }
+    ACE_Time_Value deferred_triggered_check_ttl() const { return m_deferred_triggered_check_ttl; }
+
+    void change_password_period(ACE_Time_Value const & x) { m_change_password_period = x; }
+    ACE_Time_Value change_password_period() const { return m_change_password_period; }
+
+  private:
+    // Mininum time between consecutive sends.
+    // RFC 8445 Section 14.2
+    ACE_Time_Value m_T_a;
+    // Repeat a check for this long before failing it.
+    ACE_Time_Value m_connectivity_check_ttl;
+    // Run all of the ordinary checks in a checklist in this amount of time.
+    ACE_Time_Value m_checklist_period;
+    // Send an indication at this interval once an address is selected.
+    ACE_Time_Value m_indication_period;
+    // The nominated pair will still be valid if an indication has been received within this amount of time.
+    ACE_Time_Value m_nominated_ttl;
+    // Perform server-reflexive candidate gathering this often.
+    ACE_Time_Value m_server_reflexive_address_period;
+    // Send this many binding indications to the STUN server before sending a binding request.
+    size_t m_server_reflexive_indication_count;
+    // Lifetime of a deferred triggered check.
+    ACE_Time_Value m_deferred_triggered_check_ttl;
+    // Change the password this often.
+    ACE_Time_Value m_change_password_period;
+  };
+  
+  class OpenDDS_Ice_Export Agent {
+  public:
+    virtual ~Agent() {}
+    virtual Configuration & get_configuration() = 0;
+    virtual void add_endpoint(Endpoint * a_endpoint) = 0;
+    virtual void remove_endpoint(Endpoint * a_endpoint) = 0;
+    virtual AgentInfo get_local_agent_info(Endpoint * a_endpoint) const = 0;
+    virtual void add_local_agent_info_listener(Endpoint * a_endpoint,
+                                               DCPS::RepoId const & a_local_guid,
+                                               AgentInfoListener * a_agent_info_listener) = 0;
+    virtual void remove_local_agent_info_listener(Endpoint * a_endpoint,
+                                                  DCPS::RepoId const & a_local_guid) = 0;
+    virtual void start_ice(Endpoint * a_endpoint,
+                           DCPS::RepoId const & a_local_guid,
+                           DCPS::RepoId const & a_remote_guid,
+                           AgentInfo const & a_remote_agent_info) = 0;
+    virtual void stop_ice(Endpoint * a_endpoint,
+                          DCPS::RepoId const & a_local_guid,
+                          DCPS::RepoId const & a_remote_guid) = 0;
+    virtual ACE_INET_Addr get_address(Endpoint * a_endpoint,
+                                      DCPS::RepoId const & a_local_guid,
+                                      DCPS::RepoId const & a_remote_guid) const = 0;
+
+    // Receive a STUN message.
+    virtual void receive(Endpoint * a_endpoint,
+                         ACE_INET_Addr const & a_local_address,
+                         ACE_INET_Addr const & a_remote_address,
+                         STUN::Message const & a_message) = 0;
+
+    static Agent* instance();
+  };
+
+  std::ostream& operator<<(std::ostream& stream, const ACE_INET_Addr& address);
+  std::ostream& operator<<(std::ostream& stream, const STUN::TransactionId& tid);
+  std::ostream& operator<<(std::ostream& stream, const ICE::Candidate& candidate);
+  std::ostream& operator<<(std::ostream& stream, const ICE::AgentInfo& agent_info);
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_H */

--- a/dds/DCPS/ICE/Stun.cpp
+++ b/dds/DCPS/ICE/Stun.cpp
@@ -1,0 +1,759 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Stun.h"
+
+#include <iostream>
+
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace STUN {
+
+  uint16_t Attribute::length() const {
+    switch (type) {
+    case MAPPED_ADDRESS:
+      // TODO(jrw972):  Handle IPv6.
+      return 8;
+    case USERNAME:
+      return username.size();
+    case MESSAGE_INTEGRITY:
+      return 20;
+    case ERROR_CODE:
+      return 4 + error.reason.size();
+    case UNKNOWN_ATTRIBUTES:
+      return 2 * unknown_attributes.size();
+    case XOR_MAPPED_ADDRESS:
+      // TODO(jrw972):  Handle IPv6.
+      return 8;
+    case PRIORITY:
+      return 4;
+    case USE_CANDIDATE:
+      return 0;
+    case FINGERPRINT:
+      return 4;
+    case ICE_CONTROLLED:
+    case ICE_CONTROLLING:
+      return 8;
+    }
+
+    return unknown_length;
+  }
+
+  Attribute make_mapped_address(const ACE_INET_Addr& addr) {
+    Attribute attribute;
+    attribute.type = MAPPED_ADDRESS;
+    // TODO(jrw972):  Handle IPv6.
+    attribute.mapped_address = addr;
+    return attribute;
+  }
+
+  Attribute make_username(const std::string& username) {
+    Attribute attribute;
+    attribute.type = USERNAME;
+    attribute.username = username;
+    return attribute;
+  }
+
+  Attribute make_message_integrity() {
+    Attribute attribute;
+    attribute.type = MESSAGE_INTEGRITY;
+    return attribute;
+  }
+
+  Attribute make_error_code(uint16_t code, const std::string& reason) {
+    Attribute attribute;
+    attribute.type = ERROR_CODE;
+    attribute.error.code = code;
+    attribute.error.reason = reason;
+    return attribute;
+  }
+
+  Attribute make_unknown_attributes(std::vector<AttributeType> const & unknown_attributes) {
+    Attribute attribute;
+    attribute.type = UNKNOWN_ATTRIBUTES;
+    attribute.unknown_attributes = unknown_attributes;
+    return attribute;
+  }
+
+  Attribute make_xor_mapped_address(const ACE_INET_Addr& addr) {
+    Attribute attribute;
+    attribute.type = XOR_MAPPED_ADDRESS;
+    // TODO(jrw972):  Handle IPv6.
+    attribute.mapped_address = addr;
+    return attribute;
+  }
+
+  Attribute make_priority(uint32_t priority) {
+    Attribute attribute;
+    attribute.type = PRIORITY;
+    attribute.priority = priority;
+    return attribute;
+  }
+
+  Attribute make_use_candidate() {
+    Attribute attribute;
+    attribute.type = USE_CANDIDATE;
+    return attribute;
+  }
+
+  Attribute make_fingerprint() {
+    Attribute attribute;
+    attribute.type = FINGERPRINT;
+    return attribute;
+  }
+
+  Attribute make_ice_controlling(ACE_UINT64 ice_tie_breaker) {
+    Attribute attribute;
+    attribute.type = ICE_CONTROLLING;
+    attribute.ice_tie_breaker = ice_tie_breaker;
+    return attribute;
+  }
+
+  Attribute make_ice_controlled(ACE_UINT64 ice_tie_breaker) {
+    Attribute attribute;
+    attribute.type = ICE_CONTROLLED;
+    attribute.ice_tie_breaker = ice_tie_breaker;
+    return attribute;
+  }
+
+  Attribute make_unknown_attribute(uint16_t type, uint16_t length) {
+    Attribute attribute;
+    attribute.type = static_cast<AttributeType>(type);
+    attribute.unknown_length = length;
+    return attribute;
+  }
+
+  bool operator>>(DCPS::Serializer& serializer, Attribute& attribute) {
+    uint16_t attribute_type;
+    uint16_t attribute_length;
+
+    if (!(serializer >> attribute_type)) {
+      return false;
+    }
+
+    if (!(serializer >> attribute_length)) {
+      return false;
+    }
+
+    switch (attribute_type) {
+    case MAPPED_ADDRESS:
+      {
+        ACE_CDR::Char family;
+        uint16_t port;
+        if (!serializer.skip(1)) {
+          return false;
+        }
+        if (!(serializer >> family)) {
+          return false;
+        }
+        if (!(serializer >> port)) {
+          return false;
+        }
+        if (family == IPv4) {
+          if (attribute_length != 8) {
+            return false;
+          }
+          uint32_t address;
+          if (!(serializer >> address)) {
+            return false;
+          }
+          attribute = make_mapped_address(ACE_INET_Addr(port, address));
+        } else if (family == IPv6) {
+          // TODO(jrw972):  Handle IPv6.
+        }
+      }
+      break;
+    case USERNAME:
+      {
+        if (attribute_length > 512) {
+          return false;
+        }
+        unsigned char buffer[512];
+        if (!serializer.read_octet_array(buffer, attribute_length)) {
+          return false;
+        }
+        attribute = make_username(std::string(reinterpret_cast<char*>(buffer), attribute_length));
+      }
+      break;
+    case MESSAGE_INTEGRITY:
+      {
+        attribute = make_message_integrity();
+        if (!serializer.read_octet_array(attribute.message_integrity, sizeof(attribute.message_integrity))) {
+          return false;
+        }
+      }
+      break;
+    case ERROR_CODE:
+      {
+        uint32_t x;
+        if (!(serializer >> x)) {
+          return false;
+        }
+        uint32_t class_ = (x & (0x7 << 8)) >> 8;
+        if (class_ < 3 || class_ >= 7) {
+          return false;
+        }
+        uint32_t num = x & 0xFF;
+        if (num > 100) {
+          return false;
+        }
+        uint16_t code = class_ * 100 + num;
+
+        size_t reason_length = attribute_length - 4;
+        if (reason_length > 763) {
+          return false;
+        }
+        unsigned char buffer[763];
+        if (!serializer.read_octet_array(buffer, reason_length)) {
+          return false;
+        }
+        attribute = make_error_code(code, std::string(reinterpret_cast<char*>(buffer), reason_length));
+      }
+      break;
+    case UNKNOWN_ATTRIBUTES:
+      {
+        std::vector<AttributeType> unknown_attributes;
+        for (size_t count = attribute_length / 2; count != 0; --count) {
+          uint16_t code;
+          if (!(serializer >> code)) {
+            return false;
+          }
+          unknown_attributes.push_back(static_cast<AttributeType>(code));
+        }
+        attribute = make_unknown_attributes(unknown_attributes);
+      }
+      break;
+    case XOR_MAPPED_ADDRESS:
+      {
+        ACE_CDR::Char family;
+        uint16_t port;
+        if (!serializer.skip(1)) {
+          return false;
+        }
+        if (!(serializer >> family)) {
+          return false;
+        }
+        if (!(serializer >> port)) {
+          return false;
+        }
+        port ^= MAGIC_COOKIE >> 16;
+        if (family == IPv4) {
+          if (attribute_length != 8) {
+            return false;
+          }
+          uint32_t address;
+          if (!(serializer >> address)) {
+            return false;
+          }
+          address ^= MAGIC_COOKIE;
+          attribute = make_xor_mapped_address(ACE_INET_Addr(port, address));
+        } else if (family == IPv6) {
+          // TODO(jrw972):  Handle IPv6.
+        }
+      }
+      break;
+    case PRIORITY:
+      {
+        uint32_t priority;
+        if (!(serializer >> priority)) {
+          return false;
+        }
+        attribute = make_priority(priority);
+      }
+      break;
+    case USE_CANDIDATE:
+      attribute = make_use_candidate();
+      break;
+    case FINGERPRINT:
+      {
+        attribute = make_fingerprint();
+        if (!(serializer >> attribute.fingerprint)) {
+          return false;
+        }
+      }
+      break;
+    case ICE_CONTROLLED:
+      {
+        ACE_UINT64 ice_tie_breaker;
+        if (!(serializer >> ice_tie_breaker)) {
+          return false;
+        }
+        attribute = make_ice_controlled(ice_tie_breaker);
+      }
+      break;
+    case ICE_CONTROLLING:
+      {
+        ACE_UINT64 ice_tie_breaker;
+        if (!(serializer >> ice_tie_breaker)) {
+          return false;
+        }
+        attribute = make_ice_controlling(ice_tie_breaker);
+      }
+      break;
+    default:
+      {
+        if (!serializer.skip(attribute_length)) {
+          return false;
+        }
+        attribute = make_unknown_attribute(attribute_type, attribute_length);
+      }
+      break;
+    }
+
+    // All attributes are aligned on 32-bit boundaries.
+    if (!serializer.skip((4 - (attribute_length & 0x3)) % 4)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  bool operator<<(DCPS::Serializer& serializer, const Attribute& attribute) {
+    uint16_t attribute_type = attribute.type;
+    uint16_t attribute_length = attribute.length();
+    serializer << attribute_type;
+    serializer << attribute_length;
+
+    switch (attribute_type) {
+    case MAPPED_ADDRESS:
+      {
+        serializer << static_cast<ACE_CDR::Char>(0);
+        serializer << static_cast<ACE_CDR::Char>(IPv4);
+        serializer << static_cast<uint16_t>(attribute.mapped_address.get_port_number());
+        serializer << attribute.mapped_address.get_ip_address();
+        // TODO(jrw972):  Handle IPv6.
+      }
+      break;
+    case USERNAME:
+      {
+        serializer.write_octet_array(reinterpret_cast<const ACE_CDR::Octet*>(attribute.username.c_str()), attribute.username.size());
+      }
+      break;
+    case MESSAGE_INTEGRITY:
+      {
+        serializer.write_octet_array(attribute.message_integrity, sizeof(attribute.message_integrity));
+      }
+      break;
+    case ERROR_CODE:
+      {
+        uint8_t class_ = attribute.error.code / 100;
+        uint8_t num = attribute.error.code % 100;
+        serializer << static_cast<ACE_CDR::Char>(0);
+        serializer << static_cast<ACE_CDR::Char>(0);
+        serializer << static_cast<ACE_CDR::Char>(class_);
+        serializer << static_cast<ACE_CDR::Char>(num);
+        serializer.write_octet_array(reinterpret_cast<const ACE_CDR::Octet*>(attribute.error.reason.c_str()), attribute.error.reason.size());
+      }
+      break;
+    case UNKNOWN_ATTRIBUTES:
+      {
+        for (std::vector<AttributeType>::const_iterator pos = attribute.unknown_attributes.begin(),
+               limit = attribute.unknown_attributes.end(); pos != limit; ++pos) {
+          serializer << static_cast<uint16_t>(*pos);
+        }
+      }
+      break;
+    case XOR_MAPPED_ADDRESS:
+      {
+        serializer << static_cast<ACE_CDR::Char>(0);
+        serializer << static_cast<ACE_CDR::Char>(IPv4);
+        serializer << static_cast<uint16_t>(attribute.mapped_address.get_port_number() ^ (MAGIC_COOKIE >> 16));
+        serializer << (attribute.mapped_address.get_ip_address() ^ MAGIC_COOKIE);
+        // TODO(jrw972):  Handle IPv6.
+      }
+      break;
+    case PRIORITY:
+      {
+        serializer << attribute.priority;
+      }
+      break;
+    case USE_CANDIDATE:
+      break;
+    case FINGERPRINT:
+      {
+        serializer << attribute.fingerprint;
+      }
+      break;
+    case ICE_CONTROLLED:
+    case ICE_CONTROLLING:
+      {
+        serializer << attribute.ice_tie_breaker;
+      }
+      break;
+    default:
+      // Don't serialize attributes that are not understood.
+      return false;
+      break;
+    }
+
+    // Align to 32 bits.
+    while (attribute_length % 4 != 0) {
+      serializer << static_cast<ACE_CDR::Char>(0);
+      attribute_length += 1;
+    }
+
+    return true;
+  }
+
+  bool TransactionId::operator<(const TransactionId& other) const {
+    return (memcmp(this->data, other.data, sizeof(data)) < 0);
+  }
+
+  bool TransactionId::operator==(const TransactionId& other) const {
+    return (memcmp(this->data, other.data, sizeof(data)) == 0);
+  }
+
+  bool TransactionId::operator!=(const TransactionId& other) const {
+    return (memcmp(this->data, other.data, sizeof(data)) != 0);
+  }
+
+  void Message::generate_transaction_id() {
+    int rc = RAND_bytes(transaction_id.data, sizeof(transaction_id.data));
+    if (rc != 1) {
+      unsigned long err = ERR_get_error();
+      char msg[256] = { 0 };
+      ERR_error_string_n(err, msg, sizeof(msg));
+
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) Message::generate_transaction_id: ERROR '%C' returned by RAND_bytes(...)\n"),
+                 msg));
+    }
+  }
+
+  std::vector<AttributeType> Message::unknown_comprehension_required_attributes() const {
+    std::vector<AttributeType> retval;
+
+    for (const AttributesType::value_type& attribute : m_attributes) {
+      switch (attribute.type) {
+      case MAPPED_ADDRESS:
+      case USERNAME:
+      case MESSAGE_INTEGRITY:
+      case ERROR_CODE:
+      case UNKNOWN_ATTRIBUTES:
+      case XOR_MAPPED_ADDRESS:
+      case PRIORITY:
+      case USE_CANDIDATE:
+        break;
+      default:
+        if (attribute.type < 0x8000) {
+          retval.push_back(attribute.type);
+        }
+      }
+    }
+
+    return retval;
+  }
+
+  bool Message::get_mapped_address(ACE_INET_Addr& address) const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::XOR_MAPPED_ADDRESS) {
+        address = pos->mapped_address;
+        return true;
+      }
+    }
+
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::MAPPED_ADDRESS) {
+        address = pos->mapped_address;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool Message::get_priority(uint32_t& priority) const {
+    bool flag = false;
+
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::PRIORITY) {
+        flag = true;
+        priority = pos->priority;
+        // Use the last.
+      }
+    }
+
+    return flag;
+  }
+
+  bool Message::get_username(std::string& username) const {
+    bool flag = false;
+
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::USERNAME) {
+        flag = true;
+        username = pos->username;
+        // Use the last.
+      }
+    }
+
+    return flag;
+  }
+
+  bool Message::has_message_integrity() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::MESSAGE_INTEGRITY) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool Message::verify_message_integrity(const std::string& password) const {
+    bool verified = false;
+
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::MESSAGE_INTEGRITY) {
+        unsigned char computed_message_integrity[20];
+        compute_message_integrity(password, computed_message_integrity);
+        verified = memcmp(computed_message_integrity, pos->message_integrity, 20) == 0;
+        // Use the last.
+      }
+    }
+
+    return verified;
+  }
+
+  void Message::compute_message_integrity(const std::string& password, unsigned char message_integrity[20]) const {
+    ACE_Message_Block* block = this->block->duplicate();
+    block->rd_ptr(block->base());
+    DCPS::Serializer serializer(block, true);
+
+    // Write the length and resize for hashing.
+    block->wr_ptr(block->base() + 2);
+    uint16_t message_length = length_for_message_integrity();
+    serializer << message_length;
+    block->wr_ptr(block->base() + 20 + length_for_message_integrity() - 24);
+
+    // Compute the SHA1.
+    unsigned char* digest = HMAC(EVP_sha1(), password.c_str(), password.size(),
+                                 reinterpret_cast<unsigned char*>(block->rd_ptr()), block->length(), NULL, NULL);
+    memcpy(message_integrity, digest, 20);
+
+    // Write the correct length.
+    block->wr_ptr(block->base() + 2);
+    message_length = length();
+    serializer << message_length;
+
+    block->release();
+  }
+
+  bool Message::has_error_code() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::ERROR_CODE) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  uint16_t Message::get_error_code() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::ERROR_CODE) {
+        return pos->error.code;
+      }
+    }
+
+    return 0;
+  }
+
+  std::string Message::get_error_reason() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::ERROR_CODE) {
+        return pos->error.reason;
+      }
+    }
+
+    return std::string();
+  }
+
+  bool Message::has_unknown_attributes() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::UNKNOWN_ATTRIBUTES) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  std::vector<AttributeType> Message::get_unknown_attributes() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::UNKNOWN_ATTRIBUTES) {
+        return pos->unknown_attributes;
+      }
+    }
+
+    return std::vector<AttributeType>();
+  }
+
+
+  bool Message::has_fingerprint() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::FINGERPRINT) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  uint32_t Message::compute_fingerprint() const {
+    ACE_Message_Block* block = this->block->duplicate();
+    block->rd_ptr(block->base());
+    DCPS::Serializer serializer(block, true);
+
+    // Resize for hashing.
+    block->wr_ptr(block->base() + 20 + length() - 8);
+
+    // Compute the CRC-32
+    uint32_t crc = ACE::crc32(block->rd_ptr(), block->length());
+
+    block->release();
+
+    return crc ^ 0x5354554E;
+  }
+
+  bool Message::has_ice_controlled() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::ICE_CONTROLLED) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool Message::has_ice_controlling() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::ICE_CONTROLLING) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool Message::has_use_candidate() const {
+    for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+      if (pos->type == STUN::USE_CANDIDATE) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool operator>>(DCPS::Serializer& serializer, Message& message) {
+    uint16_t message_type;
+    uint16_t message_length;
+    uint32_t magic_cookie;
+
+    if (!(serializer >> message_type)) {
+      return false;
+    }
+    if (!(serializer >> message_length)) {
+      return false;
+    }
+
+    if ((message_type & 0xC000) != 0) {
+      return false;
+    }
+    if (message_length % 4 != 0) {
+      return false;
+    }
+
+    message.class_ = static_cast<Class>(((message_type & (1 << 8)) >> 7) | ((message_type & (1 << 4)) >> 4));
+    message.method = static_cast<Method>(((message_type & 0x3E00) >> 2) | ((message_type & 0xE0) >> 1) | (message_type & 0xF));
+
+    if (!(serializer >> magic_cookie)) {
+      return false;
+    }
+
+    if (magic_cookie != MAGIC_COOKIE) {
+      return false;
+    }
+
+    if (!serializer.read_octet_array(message.transaction_id.data, 12)) {
+      return false;
+    }
+
+    // At this point there should be message.length bytes remaining.
+    if (serializer.length() != message_length) {
+      return false;
+    }
+
+    while (serializer.length() != 0) {
+      bool have_integrity = false;
+      bool have_fingerprint = false;
+
+      Attribute attribute;
+      if (!(serializer >> attribute)) {
+        return false;
+      }
+      message.append_attribute(attribute);
+      if ((have_integrity && attribute.type != FINGERPRINT) || have_fingerprint) {
+        return false;
+      }
+      if (attribute.type == FINGERPRINT && attribute.fingerprint != message.compute_fingerprint()) {
+        return false;
+      }
+      if (message.length() > message_length) {
+        return false;
+      }
+
+      have_integrity = have_integrity || attribute.type == MESSAGE_INTEGRITY;
+      have_fingerprint = have_fingerprint || attribute.type == FINGERPRINT;
+    }
+
+    return true;
+  }
+
+  bool operator<<(DCPS::Serializer& serializer, const Message& message) {
+    uint16_t message_class = message.class_;
+    uint16_t message_method = message.method;
+    uint16_t message_type =
+      ((message_method & 0xF80) << 2) |
+      ((message_class & 0x2) << 7) |
+      ((message_method & 0x0070) << 1) |
+      ((message_class & 0x1) << 4) |
+      (message_method & 0x000F);
+    serializer << message_type;
+
+    uint16_t message_length = message.length();
+    serializer << message_length;
+    serializer << MAGIC_COOKIE;
+    serializer.write_octet_array(message.transaction_id.data, sizeof(message.transaction_id.data));
+
+    for (Message::const_iterator pos = message.begin(), limit = message.end();
+         pos != limit; ++pos) {
+      const Attribute& attribute = *pos;
+      if (attribute.type == MESSAGE_INTEGRITY) {
+        // Compute the hash.
+        message.compute_message_integrity(message.password, const_cast<Attribute&>(attribute).message_integrity);
+      } else if (attribute.type == FINGERPRINT) {
+        // Compute the hash.
+        const_cast<Attribute&>(attribute).fingerprint = message.compute_fingerprint();
+      }
+      serializer << attribute;
+    }
+
+    return true;
+  }
+
+
+} // namespace STUN
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ICE/Stun.h
+++ b/dds/DCPS/ICE/Stun.h
@@ -1,0 +1,194 @@
+
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_STUN_H
+#define OPENDDS_RTPS_STUN_H
+
+#include <map>
+
+#include "ace/INET_Addr.h"
+#include "dds/DCPS/Serializer.h"
+
+#include "ice_export.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace STUN {
+  namespace DCPS = OpenDDS::DCPS;
+
+  enum Class {
+    REQUEST          = 0,
+    INDICATION       = 1,
+    SUCCESS_RESPONSE = 2 ,
+    ERROR_RESPONSE   = 3
+  };
+
+  enum Method {
+    BINDING = 0x001
+  };
+
+  enum Family {
+    IPv4 = 0x01,
+    IPv6 = 0x02
+  };
+
+  const uint32_t MAGIC_COOKIE = 0x2112A442;
+
+  enum AttributeType {
+    MAPPED_ADDRESS     = 0x0001,
+    USERNAME           = 0x0006,
+    MESSAGE_INTEGRITY  = 0x0008,
+    ERROR_CODE         = 0x0009,
+    UNKNOWN_ATTRIBUTES = 0x000A,
+    // REALM              = 0x0014,
+    // NONCE              = 0x0015,
+    XOR_MAPPED_ADDRESS = 0x0020,
+    PRIORITY           = 0x0024,
+    USE_CANDIDATE      = 0x0025,
+
+    // SOFTWARE           = 0x8022,
+    // ALTERNATE_SERVER   = 0x8023,
+    FINGERPRINT        = 0x8028,
+    ICE_CONTROLLED     = 0x8029,
+    ICE_CONTROLLING    = 0x802A
+  };
+
+  struct Attribute {
+    AttributeType type;
+
+    ACE_INET_Addr mapped_address; // MAPPED_ADDRESS, XOR_MAPPED_ADDRESS
+    std::string username; // USERNAME
+    union {
+      unsigned char message_integrity[20]; // MESSAGE_INTEGRITY
+      uint32_t fingerprint; // FINGERPRINT
+      uint32_t priority; // PRIORITY
+      ACE_UINT64 ice_tie_breaker; // ICE_CONTROLLED, ICE_CONTROLLING
+    };
+    struct {
+      uint16_t code;
+      std::string reason;
+    } error;
+    std::vector<AttributeType> unknown_attributes;
+
+    uint16_t unknown_length;
+
+    uint16_t length() const;
+  };
+
+  Attribute make_mapped_address(const ACE_INET_Addr& addr);
+  Attribute make_username(const std::string& username);
+  Attribute make_message_integrity();
+  Attribute make_error_code(uint16_t code, const std::string& reason);
+  Attribute make_unknown_attributes(std::vector<AttributeType> const & unknown_attributes);
+  Attribute make_xor_mapped_address(const ACE_INET_Addr& addr);
+  Attribute make_unknown_attribute(uint16_t type, uint16_t length);
+  Attribute make_priority(uint32_t priority);
+  Attribute make_use_candidate();;
+
+  Attribute make_fingerprint();
+  Attribute make_ice_controlling(ACE_UINT64 ice_tie_breaker);
+  Attribute make_ice_controlled(ACE_UINT64 ice_tie_breaker);
+
+  bool operator>>(DCPS::Serializer& serializer, Attribute& attribute);
+  bool operator<<(DCPS::Serializer& serializer, const Attribute& attribute);
+
+  struct TransactionId {
+    uint8_t data[12];
+    bool operator<(const TransactionId& other) const;
+    bool operator==(const TransactionId& other) const;
+    bool operator!=(const TransactionId& other) const;
+  };
+
+  struct Message {
+    typedef std::vector<Attribute> AttributesType;
+    typedef AttributesType::const_iterator const_iterator;
+
+    Class class_;
+    Method method;
+    TransactionId transaction_id;
+
+    Message()
+    : block(0), m_length(0), m_length_for_message_integrity(0) {}
+
+    void generate_transaction_id();
+
+    void append_attribute(const Attribute& attribute) {
+      m_attributes.push_back(attribute);
+      m_length += (4 + attribute.length() + 3) & ~3;
+      if (attribute.type == MESSAGE_INTEGRITY) {
+        m_length_for_message_integrity = m_length;
+      }
+    }
+
+    const_iterator begin() const { return m_attributes.begin(); }
+    const_iterator end() const { return m_attributes.end(); }
+    uint16_t length() const { return m_length; }
+    uint16_t length_for_message_integrity() const { return m_length_for_message_integrity; }
+
+    std::vector<AttributeType> unknown_comprehension_required_attributes() const;
+    bool get_mapped_address(ACE_INET_Addr& address) const;
+    bool get_priority(uint32_t& priority) const;
+    bool get_username(std::string& username) const;
+    bool has_message_integrity() const;
+    bool verify_message_integrity(const std::string& password) const;
+    void compute_message_integrity(const std::string& password, unsigned char message_integrity[20]) const;
+    bool has_error_code() const;
+    uint16_t get_error_code() const;
+    std::string get_error_reason() const;
+    bool has_unknown_attributes() const;
+    std::vector<AttributeType> get_unknown_attributes() const;
+    bool has_fingerprint() const;
+    uint32_t compute_fingerprint() const;
+    bool has_ice_controlled() const;
+    bool has_ice_controlling() const;
+    bool has_use_candidate() const;
+
+    ACE_Message_Block* block;
+    std::string password; // For integrity hashing.
+
+  private:
+    AttributesType m_attributes;
+    uint16_t m_length;
+    uint16_t m_length_for_message_integrity;
+  };
+
+  OpenDDS_Ice_Export bool operator>>(DCPS::Serializer& serializer, Message& message);
+  OpenDDS_Ice_Export bool operator<<(DCPS::Serializer& serializer, const Message& message);
+
+  class Sender {
+  public:
+    virtual void send(const ACE_INET_Addr& address, const Message& message) = 0;
+    virtual ~Sender() = default;
+  };
+
+  class OpenDDS_Ice_Export Participant {
+  public:
+    Participant(Sender* a_sender) : m_sender(a_sender) {}
+
+    void receive(const ACE_INET_Addr& address, const Message& message);
+
+  private:
+    Sender* m_sender;
+
+    void request(const ACE_INET_Addr& address, const Message& message);
+    void indication(const ACE_INET_Addr& /*address*/, const Message& message);
+    void success_response(const ACE_INET_Addr& /*address*/, const Message& /*message*/);
+    void error_response(const ACE_INET_Addr& /*address*/, const Message& /*message*/);
+  };
+
+} // namespace STUN
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_STUN_H */

--- a/dds/DCPS/ICE/Task.cpp
+++ b/dds/DCPS/ICE/Task.cpp
@@ -1,0 +1,34 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Ice.h"
+
+#include <iostream>
+#include <sstream>
+
+#include <openssl/rand.h>
+#include <openssl/err.h>
+
+#include "ace/Reactor.h"
+#include "dds/DCPS/Service_Participant.h"
+#include "Task.h"
+#include "AgentImpl.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  void Task::enqueue(ACE_Time_Value const & a_release_time) {
+    m_release_time = a_release_time;
+    m_agent_impl->enqueue(this);
+  }
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ICE/Task.h
+++ b/dds/DCPS/ICE/Task.h
@@ -1,0 +1,42 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_TASK_H
+#define OPENDDS_RTPS_ICE_TASK_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include "dds/Versioned_Namespace.h"
+#include <ace/Time_Value.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+  class AgentImpl;
+
+  struct Task {
+    Task(AgentImpl * a_agent_impl) : m_agent_impl(a_agent_impl), m_in_queue(false) {}
+    virtual ~Task() {};
+    virtual void execute(ACE_Time_Value const & a_now) = 0;
+    void enqueue(ACE_Time_Value const & release_time);
+  private:
+    friend class AgentImpl;
+    AgentImpl * m_agent_impl;
+    ACE_Time_Value m_release_time;
+    bool m_in_queue;
+  };
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_TASK_H */

--- a/dds/DCPS/ICE/ice.mpc
+++ b/dds/DCPS/ICE/ice.mpc
@@ -1,0 +1,11 @@
+project(OpenDDS_Ice): dcpslib, openssl, install {
+  sharedname = OpenDDS_Ice
+  dynamicflags = OPENDDS_ICE_BUILD_DLL
+
+  IDL_Files {
+  }
+
+  specific {
+    install_dir = dds/DCPS/ICE
+  }
+}

--- a/dds/DCPS/ICE/ice_export.h
+++ b/dds/DCPS/ICE/ice_export.h
@@ -1,0 +1,57 @@
+
+// -*- C++ -*-
+// Definition for Win32 Export directives.
+// This file is generated automatically by generate_export_file.pl OpenDDS_Ice
+// ------------------------------
+#ifndef OPENDDS_ICE_EXPORT_H
+#define OPENDDS_ICE_EXPORT_H
+
+#include "ace/config-all.h"
+
+#if defined (ACE_AS_STATIC_LIBS) && !defined (OPENDDS_ICE_HAS_DLL)
+#  define OPENDDS_ICE_HAS_DLL 0
+#endif /* ACE_AS_STATIC_LIBS && OPENDDS_ICE_HAS_DLL */
+
+#if !defined (OPENDDS_ICE_HAS_DLL)
+#  define OPENDDS_ICE_HAS_DLL 1
+#endif /* ! OPENDDS_ICE_HAS_DLL */
+
+#if defined (OPENDDS_ICE_HAS_DLL) && (OPENDDS_ICE_HAS_DLL == 1)
+#  if defined (OPENDDS_ICE_BUILD_DLL)
+#    define OpenDDS_Ice_Export ACE_Proper_Export_Flag
+#    define OPENDDS_ICE_SINGLETON_DECLARATION(T) ACE_EXPORT_SINGLETON_DECLARATION (T)
+#    define OPENDDS_ICE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK) ACE_EXPORT_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
+#  else /* OPENDDS_ICE_BUILD_DLL */
+#    define OpenDDS_Ice_Export ACE_Proper_Import_Flag
+#    define OPENDDS_ICE_SINGLETON_DECLARATION(T) ACE_IMPORT_SINGLETON_DECLARATION (T)
+#    define OPENDDS_ICE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK) ACE_IMPORT_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
+#  endif /* OPENDDS_ICE_BUILD_DLL */
+#else /* OPENDDS_ICE_HAS_DLL == 1 */
+#  define OpenDDS_Ice_Export
+#  define OPENDDS_ICE_SINGLETON_DECLARATION(T)
+#  define OPENDDS_ICE_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
+#endif /* OPENDDS_ICE_HAS_DLL == 1 */
+
+// Set OPENDDS_ICE_NTRACE = 0 to turn on library specific tracing even if
+// tracing is turned off for ACE.
+#if !defined (OPENDDS_ICE_NTRACE)
+#  if (ACE_NTRACE == 1)
+#    define OPENDDS_ICE_NTRACE 1
+#  else /* (ACE_NTRACE == 1) */
+#    define OPENDDS_ICE_NTRACE 0
+#  endif /* (ACE_NTRACE == 1) */
+#endif /* !OPENDDS_ICE_NTRACE */
+
+#if (OPENDDS_ICE_NTRACE == 1)
+#  define OPENDDS_ICE_TRACE(X)
+#else /* (OPENDDS_ICE_NTRACE == 1) */
+#  if !defined (ACE_HAS_TRACE)
+#    define ACE_HAS_TRACE
+#  endif /* ACE_HAS_TRACE */
+#  define OPENDDS_ICE_TRACE(X) ACE_TRACE_IMPL(X)
+#  include "ace/Trace.h"
+#endif /* (OPENDDS_ICE_NTRACE == 1) */
+
+#endif /* OPENDDS_ICE_EXPORT_H */
+
+// End of auto generated file.

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1507,7 +1507,7 @@ int from_param_list(const ParameterList& param_list,
   return 0;
 }
 
-int to_param_list(const DiscoveredWriterData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map)
 {
@@ -1520,7 +1520,7 @@ int to_param_list(const DiscoveredWriterData_SecurityWrapper& wrapper,
 }
 
 int from_param_list(const ParameterList& param_list,
-                    DiscoveredWriterData_SecurityWrapper& wrapper)
+                    DiscoveredPublication_SecurityWrapper& wrapper)
 {
   int result = from_param_list(param_list, wrapper.data) ||
                from_param_list(param_list, wrapper.security_info) ||
@@ -1529,7 +1529,7 @@ int from_param_list(const ParameterList& param_list,
   return result;
 }
 
-int to_param_list(const DiscoveredReaderData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map)
 {
@@ -1542,7 +1542,7 @@ int to_param_list(const DiscoveredReaderData_SecurityWrapper& wrapper,
 }
 
 int from_param_list(const ParameterList& param_list,
-                    DiscoveredReaderData_SecurityWrapper& wrapper)
+                    DiscoveredSubscription_SecurityWrapper& wrapper)
 {
   int result = from_param_list(param_list, wrapper.data) ||
                from_param_list(param_list, wrapper.security_info) ||
@@ -1551,6 +1551,77 @@ int from_param_list(const ParameterList& param_list,
   return result;
 }
 #endif
+
+int to_param_list(const ICE::AgentInfo& agent_info,
+                  ParameterList& param_list)
+{
+  IceGeneral_t ice_general;
+  ice_general.agent_type = agent_info.type;
+  ice_general.username = agent_info.username.c_str();
+  ice_general.password = agent_info.password.c_str();
+
+  Parameter param_general;
+  param_general.ice_general(ice_general);
+  add_param(param_list, param_general);
+
+  for (ICE::AgentInfo::CandidatesType::const_iterator pos = agent_info.candidates.begin(),
+         limit = agent_info.candidates.end(); pos != limit; ++pos) {
+    IceCandidate_t ice_candidate;
+    ice_candidate.locator.kind = LOCATOR_KIND_UDPv4;
+    sockaddr_in const * in = static_cast<const sockaddr_in*>(pos->address.get_addr());
+    std::memset(&ice_candidate.locator.address[0], 0, 12);
+    std::memcpy(&ice_candidate.locator.address[12], &in->sin_addr, 4);
+    ice_candidate.locator.port = pos->address.get_port_number();
+    ice_candidate.foundation = pos->foundation.c_str();
+    ice_candidate.priority = pos->priority;
+    ice_candidate.type = pos->type;
+
+    Parameter param;
+    param.ice_candidate(ice_candidate);
+    add_param(param_list, param);
+  }
+
+  return 0;
+}
+
+int from_param_list(const ParameterList& param_list,
+                    ICE::AgentInfo& agent_info,
+                    bool& have_agent_info)
+{
+  have_agent_info = false;
+  for (size_t idx = 0, count = param_list.length(); idx != count; ++idx) {
+    const Parameter& parameter = param_list[idx];
+    switch (parameter._d()) {
+    case PID_OPENDDS_ICE_GENERAL: {
+      have_agent_info = true;
+      const IceGeneral_t& ice_general = parameter.ice_general();
+      agent_info.type = static_cast<ICE::AgentType>(ice_general.agent_type);
+      agent_info.username = ice_general.username;
+      agent_info.password = ice_general.password;
+      break;
+    }
+    case PID_OPENDDS_ICE_CANDIDATE: {
+      have_agent_info = true;
+      const IceCandidate_t& ice_candidate = parameter.ice_candidate();
+      ICE::Candidate candidate;
+      candidate.address.set_type(AF_INET);
+      if (candidate.address.set_address(reinterpret_cast<const char*>(parameter.locator().address) + 12, 4, 0 /*network order*/) != 0) {
+        return -1;
+      }
+      candidate.address.set_port_number(parameter.locator().port);
+      candidate.foundation = ice_candidate.foundation;
+      candidate.priority = ice_candidate.priority;
+      candidate.type = static_cast<ICE::CandidateType>(ice_candidate.type);
+      agent_info.candidates.push_back(candidate);
+      break;
+    }
+    default:
+      // Do nothing.
+      break;
+    }
+  }
+  return 0;
+}
 
 } // ParameterListConverter
 } // RTPS

--- a/dds/DCPS/RTPS/ParameterListConverter.h
+++ b/dds/DCPS/RTPS/ParameterListConverter.h
@@ -10,6 +10,8 @@
 #include "dds/DCPS/RTPS/rtps_export.h"
 #include "dds/DCPS/RTPS/RtpsCoreC.h"
 
+#include "dds/DCPS/ICE/Ice.h"
+
 #ifdef OPENDDS_SECURITY
 #include "dds/DCPS/RTPS/RtpsSecurityC.h"
 #endif
@@ -20,8 +22,8 @@ namespace OpenDDS {
 namespace RTPS {
 
 #ifdef OPENDDS_SECURITY
-struct DiscoveredWriterData_SecurityWrapper;
-struct DiscoveredReaderData_SecurityWrapper;
+struct DiscoveredPublication_SecurityWrapper;
+struct DiscoveredSubscription_SecurityWrapper;
 #endif
 
 namespace ParameterListConverter {
@@ -120,7 +122,7 @@ int to_param_list(const DCPS::DiscoveredReaderData& reader_data,
 
 OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
-                   DCPS::DiscoveredReaderData& reader_data);
+                    DCPS::DiscoveredReaderData& reader_data);
 
 #ifdef OPENDDS_SECURITY
 // DDS::Security::EndpointSecurityInfo
@@ -143,28 +145,40 @@ OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
                     DDS::Security::DataTags& tags);
 
-// DiscoveredWriterData_SecurityWrapper
+// DiscoveredPublication_SecurityWrapper
 
 OpenDDS_Rtps_Export
-int to_param_list(const DiscoveredWriterData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
-                   DiscoveredWriterData_SecurityWrapper& wrapper);
+                    DiscoveredPublication_SecurityWrapper& wrapper);
 
-// DiscoveredReaderData_SecurityWrapper
+// DiscoveredSubscription_SecurityWrapper
 
 OpenDDS_Rtps_Export
-int to_param_list(const DiscoveredReaderData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
-                   DiscoveredReaderData_SecurityWrapper& wrapper);
+                    DiscoveredSubscription_SecurityWrapper& wrapper);
 #endif
+
+
+// Extensions for ICE
+
+OpenDDS_Rtps_Export
+int to_param_list(const ICE::AgentInfo& agent_info,
+                  ParameterList& param_list);
+
+OpenDDS_Rtps_Export
+int from_param_list(const ParameterList& param_list,
+                    ICE::AgentInfo& agent_info,
+                    bool& have_agent_info);
 
 }
 }

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -19,6 +19,7 @@ module OpenDDS {
 
     typedef octet OctetArray2[2];
     typedef octet OctetArray4[4];
+    typedef octet OctetArray16[16];
 
     /* A list of filters that were applied to the sample.
        See section 9.6.3.1 for the signature-generation algorithm. */
@@ -156,6 +157,35 @@ module OpenDDS {
     };
     // see VENDORID_* constants in BaseMessageTypes.h
 
+    typedef unsigned long IceAgentType_t;
+    const IceAgentType_t ICE_FULL = 0x0;
+    const IceAgentType_t ICE_LITE = 0x1;
+
+    struct IceGeneral_t {
+      IceAgentType_t agent_type;
+      // Optional Connectivity-Check Pacing Value
+      string username;
+      string password;
+      // Optional Extensions
+    };
+
+    typedef unsigned long IceCandidateType_t;
+    const IceCandidateType_t ICE_HOST = 0x0;
+    const IceCandidateType_t ICE_SERVER_REFLEXIVE = 0x1;
+    const IceCandidateType_t ICE_PEER_REFLEXIVE = 0x2;
+    const IceCandidateType_t ICE_RELAYED = 0x3;
+
+    struct IceCandidate_t {
+      DCPS::Locator_t locator;
+      // Optional Transport
+      string foundation;
+      // Optional Component ID
+      unsigned long priority;
+      IceCandidateType_t type;
+      // Related Address and Port
+      // Extensibility Parameters
+    };
+    
     typedef unsigned long BuiltinEndpointSet_t;
     const BuiltinEndpointSet_t DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER =
       1 << 0;
@@ -272,6 +302,8 @@ module OpenDDS {
     const ParameterId_t PID_OPENDDS_BASE = PIDMASK_VENDOR_SPECIFIC + 0x3000;
     const ParameterId_t PID_OPENDDS_LOCATOR           = PID_OPENDDS_BASE + 1;
     const ParameterId_t PID_OPENDDS_ASSOCIATED_WRITER = PID_OPENDDS_BASE + 2;
+    const ParameterId_t PID_OPENDDS_ICE_GENERAL       = PID_OPENDDS_BASE + 3;
+    const ParameterId_t PID_OPENDDS_ICE_CANDIDATE     = PID_OPENDDS_BASE + 4;
 
 
     /* Always used inside a ParameterList */
@@ -430,6 +462,12 @@ module OpenDDS {
       case DDS::Security::PID_IDENTITY_STATUS_TOKEN:
         DDS::Security::IdentityStatusToken identity_status_token;
 #endif
+
+      case PID_OPENDDS_ICE_GENERAL:
+        IceGeneral_t ice_general;
+
+      case PID_OPENDDS_ICE_CANDIDATE:
+        IceCandidate_t ice_candidate;
 
       default:
         DDS::OctetSeq unknown_data;

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -50,7 +50,11 @@ RtpsDiscovery::RtpsDiscovery(const RepoKey& key)
   , dx_(2)
   , ttl_(1)
   , sedp_multicast_(true)
-  , default_multicast_group_("239.255.0.1")
+  , default_multicast_group_("239.255.0.1") /*RTPS v2.1 9.6.1.4.1*/
+  , use_ice_(false)
+  , max_spdp_timer_period_(0, 10000)
+  , max_auth_time_(300, 0)
+  , auth_resend_period_(1, 0)
 {
 }
 
@@ -93,22 +97,11 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
          it != keys.end(); ++it) {
       const OPENDDS_STRING& rtps_name = it->first;
 
-      int resend = 0;
-      u_short pb = 0, dg = 0, pg = 0, d0 = 0, d1 = 0, dx = 0;
-      unsigned char ttl = 0;
-      AddrVec spdp_send_addrs;
-      OPENDDS_STRING default_multicast_group = "239.255.0.1" /*RTPS v2.1 9.6.1.4.1*/;
-      OPENDDS_STRING mi, sla, gi;
-      OPENDDS_STRING spdpaddr;
-      ACE_INET_Addr spdp_rtps_relay_address;
-      ACE_INET_Addr sedp_rtps_relay_address;
-      bool has_resend = false, has_pb = false, has_dg = false, has_pg = false,
-        has_d0 = false, has_d1 = false, has_dx = false, has_sm = false,
-        has_ttl = false, sm = false;
+      RtpsDiscovery_rch discovery (OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name));
 
       // spdpaddr defaults to DCPSDefaultAddress if set
       if (!TheServiceParticipant->default_address().empty()) {
-        spdpaddr = TheServiceParticipant->default_address().c_str();
+        discovery->spdp_local_address(TheServiceParticipant->default_address().c_str());
       }
 
       DCPS::ValueMap values;
@@ -118,110 +111,116 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
         const OPENDDS_STRING& name = it->first;
         if (name == "ResendPeriod") {
           const OPENDDS_STRING& value = it->second;
-          has_resend = DCPS::convertToInteger(value, resend);
-          if (!has_resend) {
+          int resend;
+          if (!DCPS::convertToInteger(value, resend)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for ResendPeriod in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->resend_period(ACE_Time_Value(resend));
         } else if (name == "PB") {
           const OPENDDS_STRING& value = it->second;
-          has_pb = DCPS::convertToInteger(value, pb);
-          if (!has_pb) {
+          u_short pb;
+          if (!DCPS::convertToInteger(value, pb)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for PB in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->pb(pb);
         } else if (name == "DG") {
           const OPENDDS_STRING& value = it->second;
-          has_dg = DCPS::convertToInteger(value, dg);
-          if (!has_dg) {
+          u_short dg;
+          if (!DCPS::convertToInteger(value, dg)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for DG in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->dg(dg);
         } else if (name == "PG") {
           const OPENDDS_STRING& value = it->second;
-          has_pg = DCPS::convertToInteger(value, pg);
-          if (!has_pg) {
+          u_short pg;
+          if (!DCPS::convertToInteger(value, pg)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for PG in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->pg(pg);
         } else if (name == "D0") {
           const OPENDDS_STRING& value = it->second;
-          has_d0 = DCPS::convertToInteger(value, d0);
-          if (!has_d0) {
+          u_short d0;
+          if (!DCPS::convertToInteger(value, d0)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for D0 in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->d0(d0);
         } else if (name == "D1") {
           const OPENDDS_STRING& value = it->second;
-          has_d1 = DCPS::convertToInteger(value, d1);
-          if (!has_d1) {
+          u_short d1;
+          if (!DCPS::convertToInteger(value, d1)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for D1 in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->d1(d1);
         } else if (name == "DX") {
           const OPENDDS_STRING& value = it->second;
-          has_dx = DCPS::convertToInteger(value, dx);
-          if (!has_dx) {
+          u_short dx;
+          if (!DCPS::convertToInteger(value, dx)) {
             ACE_ERROR_RETURN((LM_ERROR,
                ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
                ACE_TEXT("Invalid entry (%C) for DX in ")
                ACE_TEXT("[rtps_discovery/%C] section.\n"),
                value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->dx(dx);
         } else if (name == "TTL") {
           const OPENDDS_STRING& value = it->second;
           unsigned short ttl_us;
-          has_ttl = DCPS::convertToInteger(value, ttl_us);
-          ttl = static_cast<unsigned char>(ttl_us);
-          if (!has_ttl || ttl_us > UCHAR_MAX) {
+          if (!DCPS::convertToInteger(value, ttl_us) || ttl_us > UCHAR_MAX) {
             ACE_ERROR_RETURN((LM_ERROR,
                ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
                ACE_TEXT("Invalid entry (%C) for TTL in ")
                ACE_TEXT("[rtps_discovery/%C] section.\n"),
                value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->ttl(static_cast<unsigned char>(ttl_us));
         } else if (name == "SedpMulticast") {
           const OPENDDS_STRING& value = it->second;
           int smInt;
-          has_sm = DCPS::convertToInteger(value, smInt);
-          if (!has_sm) {
+          if (!DCPS::convertToInteger(value, smInt)) {
             ACE_ERROR_RETURN((LM_ERROR,
                ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config ")
                ACE_TEXT("Invalid entry (%C) for SedpMulticast in ")
                ACE_TEXT("[rtps_discovery/%C] section.\n"),
                value.c_str(), rtps_name.c_str()), -1);
           }
-          sm = bool(smInt);
+          discovery->sedp_multicast(bool(smInt));
         } else if (name == "MulticastInterface") {
-          mi = it->second;
+          discovery->multicast_interface(it->second);
         } else if (name == "SedpLocalAddress") {
-          sla = it->second;
+          discovery->sedp_local_address(it->second);
         } else if (name == "SpdpLocalAddress") {
-          spdpaddr = it->second;
+          discovery->spdp_local_address(it->second);
         } else if (name == "GuidInterface") {
-          gi = it->second;
+          discovery->guid_interface(it->second);
         } else if (name == "InteropMulticastOverride") {
           /// FUTURE: handle > 1 group.
-          default_multicast_group = it->second;
+          discovery->default_multicast_group(it->second);
         } else if (name == "SpdpSendAddrs") {
+          AddrVec spdp_send_addrs;
           const OPENDDS_STRING& value = it->second;
           size_t i = 0;
           do {
@@ -230,11 +229,180 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
             spdp_send_addrs.push_back(value.substr(i, (n == OPENDDS_STRING::npos) ? n : n - i));
             i = value.find(',', i);
           } while (i++ != OPENDDS_STRING::npos); // skip past comma if there is one
+          discovery->spdp_send_addrs().swap(spdp_send_addrs);
         } else if (name == "SpdpRtpsRelayAddress") {
-          spdp_rtps_relay_address = ACE_INET_Addr(it->second.c_str());
+          discovery->spdp_rtps_relay_address(ACE_INET_Addr(it->second.c_str()));
         } else if (name == "SedpRtpsRelayAddress") {
-          sedp_rtps_relay_address = ACE_INET_Addr(it->second.c_str());
-        } else {
+          discovery->sedp_rtps_relay_address(ACE_INET_Addr(it->second.c_str()));
+        } else if (name == "SedpStunServerAddress") {
+          discovery->sedp_stun_server_address(ACE_INET_Addr(it->second.c_str()));
+        } else if (name == "UseIce") {
+          const OPENDDS_STRING& value = it->second;
+          int smInt;
+          if (!DCPS::convertToInteger(value, smInt)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config ")
+                              ACE_TEXT("Invalid entry (%C) for UseIce in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              value.c_str(), rtps_name.c_str()), -1);
+          }
+          discovery->use_ice(bool(smInt));
+        } else if (name == "IceTa") {
+          // In milliseconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().T_a(ACE_Time_Value(0, int_value * 1000));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceTa in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceConnectivityCheckTTL") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().connectivity_check_ttl(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceConnectivityCheckTTL in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceChecklistPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().checklist_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceChecklistPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceIndicationPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().indication_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceIndicationPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceNominatedTTL") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().nominated_ttl(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceNominatedTTL in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceServerReflexiveAddressPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().server_reflexive_address_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceServerReflexiveAddressPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceServerReflexiveIndicationCount") {
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().server_reflexive_indication_count(int_value);
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceServerReflexiveIndicationCount in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceDeferredTriggeredCheckTTL") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().deferred_triggered_check_ttl(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceDeferredTriggeredCheckTTL in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceChangePasswordPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().change_password_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceChangePasswordPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "MaxSpdpTimerPeriod") {
+          // In milliseconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            discovery->max_spdp_timer_period(ACE_Time_Value(0, int_value * 1000));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("Invalid entry (%C) for MaxSpdpTimerPeriod in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "MaxAuthTime") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            discovery->max_auth_time(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("Invalid entry (%C) for MaxAuthTime in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "AuthResendPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            discovery->auth_resend_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("Invalid entry (%C) for AuthResendPeriod in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        }  else {
           ACE_ERROR_RETURN((LM_ERROR,
                             ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
                             ACE_TEXT("Unexpected entry (%C) in [rtps_discovery/%C] section.\n"),
@@ -243,24 +411,6 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
         }
       }
 
-      RtpsDiscovery_rch discovery (OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name));
-      if (has_resend) discovery->resend_period(ACE_Time_Value(resend));
-      if (has_pb) discovery->pb(pb);
-      if (has_dg) discovery->dg(dg);
-      if (has_pg) discovery->pg(pg);
-      if (has_d0) discovery->d0(d0);
-      if (has_d1) discovery->d1(d1);
-      if (has_dx) discovery->dx(dx);
-      if (has_ttl) discovery->ttl(ttl);
-      if (has_sm) discovery->sedp_multicast(sm);
-      discovery->multicast_interface(mi);
-      discovery->default_multicast_group(default_multicast_group);
-      discovery->spdp_send_addrs().swap(spdp_send_addrs);
-      discovery->spdp_rtps_relay_address(spdp_rtps_relay_address);
-      discovery->sedp_rtps_relay_address(sedp_rtps_relay_address);
-      discovery->sedp_local_address(sla);
-      discovery->guid_interface(gi);
-      discovery->spdp_local_address(spdpaddr);
       TheServiceParticipant->add_discovery(discovery);
     }
   }

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -151,6 +151,25 @@ public:
     sedp_rtps_relay_address_ = address;
   }
 
+  const ACE_INET_Addr& sedp_stun_server_address() const { return sedp_stun_server_address_; }
+  void sedp_stun_server_address(const ACE_INET_Addr& address) {
+    sedp_stun_server_address_ = address;
+  }
+
+  bool use_ice() const { return use_ice_; }
+  void use_ice(bool ui) {
+    use_ice_ = ui;
+  }
+
+  const ACE_Time_Value& max_spdp_timer_period() const { return max_spdp_timer_period_; }
+  void max_spdp_timer_period(const ACE_Time_Value& x) { max_spdp_timer_period_ = x; }
+
+  const ACE_Time_Value& max_auth_time() const { return max_auth_time_; }
+  void max_auth_time(const ACE_Time_Value& x) { max_auth_time_ = x; }
+
+  const ACE_Time_Value& auth_resend_period() const { return auth_resend_period_; }
+  void auth_resend_period(const ACE_Time_Value& x) { auth_resend_period_ = x; }
+
 private:
   ACE_Time_Value resend_period_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
@@ -162,6 +181,12 @@ private:
   AddrVec spdp_send_addrs_;
   ACE_INET_Addr spdp_rtps_relay_address_;
   ACE_INET_Addr sedp_rtps_relay_address_;
+  ACE_INET_Addr sedp_stun_server_address_;
+  bool use_ice_;
+  ACE_Time_Value max_spdp_timer_period_;
+  ACE_Time_Value max_auth_time_;
+  ACE_Time_Value auth_resend_period_;
+
 
   /// Guids will be unique within this RTPS configuration
   GuidGenerator guid_gen_;

--- a/dds/DCPS/RTPS/SecurityHelpers.h
+++ b/dds/DCPS/RTPS/SecurityHelpers.h
@@ -98,16 +98,26 @@ handle_to_octets(DDS::Security::NativeCryptoHandle handle)
   return handleOctets;
 }
 
-struct DiscoveredWriterData_SecurityWrapper {
+struct DiscoveredPublication_SecurityWrapper {
   DCPS::DiscoveredWriterData data;
   DDS::Security::EndpointSecurityInfo security_info;
   DDS::Security::DataTags data_tags;
+  bool have_ice_agent_info;
+  ICE::AgentInfo ice_agent_info;
+
+  DiscoveredPublication_SecurityWrapper()
+    : have_ice_agent_info(false) {}
 };
 
-struct DiscoveredReaderData_SecurityWrapper {
+struct DiscoveredSubscription_SecurityWrapper {
   DCPS::DiscoveredReaderData data;
   DDS::Security::EndpointSecurityInfo security_info;
   DDS::Security::DataTags data_tags;
+  bool have_ice_agent_info;
+  ICE::AgentInfo ice_agent_info;
+
+  DiscoveredSubscription_SecurityWrapper()
+    : have_ice_agent_info(false) {}
 };
 
 }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -18,7 +18,10 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "dds/DCPS/GuidConverter.h"
+#include "dds/DCPS/GuidUtils.h"
 #include "dds/DCPS/Qos_Helper.h"
+
+#include "dds/DCPS/ICE/Ice.h"
 
 #ifdef OPENDDS_SECURITY
 #include "SecurityHelpers.h"
@@ -30,6 +33,8 @@
 
 #include <cstring>
 #include <stdexcept>
+
+#include "ace/Auto_Ptr.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -44,10 +49,6 @@ namespace {
   const int LEASE_MULT = 10;
   const CORBA::UShort encap_LE = 0x0300; // {PL_CDR_LE} in LE
   const CORBA::UShort encap_BE = 0x0200; // {PL_CDR_BE} in LE
-
-  const ACE_Time_Value MAX_SPDP_TIMER_PERIOD(0, 10000);
-  const ACE_Time_Value MAX_AUTH_TIME(3, 0);
-  const ACE_Time_Value AUTH_RESEND_PERIOD(0, 25000);
 
   bool disposed(const ParameterList& inlineQos)
   {
@@ -115,6 +116,7 @@ void Spdp::init(DDS::DomainId_t /*domain*/,
                        RtpsDiscovery* disco)
 {
   guid = guid_; // may have changed in SpdpTransport constructor
+
   sedp_.ignore(guid);
   sedp_.init(guid_, *disco, domain_);
 
@@ -280,6 +282,10 @@ Spdp::~Spdp()
     {
       DiscoveredParticipantIter part = participants_.find(*participant_id);
       if (part != participants_.end()) {
+        ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+        if (endpoint) {
+          stop_ice(endpoint, part->first, part->second.pdata_.participantProxy.availableBuiltinEndpoints);
+        }
         remove_discovered_participant(part);
       }
     }
@@ -463,6 +469,10 @@ Spdp::handle_participant_data(DCPS::MessageId id, const ParticipantData_t& cpdat
 #endif
 
     if (id == DCPS::DISPOSE_INSTANCE || id == DCPS::DISPOSE_UNREGISTER_INSTANCE) {
+      ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+      if (endpoint) {
+        stop_ice(endpoint, iter->first, iter->second.pdata_.participantProxy.availableBuiltinEndpoints);
+      }
       remove_discovered_participant(iter);
       return;
     }
@@ -519,6 +529,26 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
   DCPS::MessageId msg_id = (data.inlineQos.length() && disposed(data.inlineQos)) ? DCPS::DISPOSE_INSTANCE : DCPS::SAMPLE_DATA;
 
   handle_participant_data(msg_id, pdata);
+
+  ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+  if (!endpoint) {
+    return;
+  }
+
+  ICE::AgentInfo agent_info;
+  bool have_agent_info;
+  if (ParameterListConverter::from_param_list(plist, agent_info, have_agent_info) < 0) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::data_received - ")
+      ACE_TEXT("failed to convert from ParameterList to ")
+      ACE_TEXT("ICE::AgentInfo\n")));
+    return;
+  }
+
+  if (have_agent_info) {
+    start_ice(endpoint, guid, pdata.participantProxy.availableBuiltinEndpoints, agent_info);
+  } else {
+    stop_ice(endpoint, guid, pdata.participantProxy.availableBuiltinEndpoints);
+  }
 }
 
 void
@@ -769,9 +799,9 @@ Spdp::check_auth_states(const ACE_Time_Value& tv) {
     switch (pi->second.auth_state_) {
       case DCPS::AS_HANDSHAKE_REQUEST_SENT:
       case DCPS::AS_HANDSHAKE_REPLY_SENT:
-        if (tv > pi->second.auth_started_time_ + MAX_AUTH_TIME) {
+        if (tv > pi->second.auth_started_time_ + disco_->max_auth_time()) {
           to_erase.insert(pi->first);
-        } else if (pi->second.has_last_stateless_msg_ && (tv > (pi->second.last_stateless_msg_time_ + AUTH_RESEND_PERIOD))) {
+        } else if (pi->second.has_last_stateless_msg_ && (tv > (pi->second.last_stateless_msg_time_ + disco_->auth_resend_period()))) {
           RepoId reader = pi->first;
           reader.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
           pi->second.last_stateless_msg_time_ = tv;
@@ -796,6 +826,10 @@ Spdp::check_auth_states(const ACE_Time_Value& tv) {
     if (pit != participants_.end()) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DEBUG: Spdp::check_auth_states()      - Removing discovered participant due to authentication timeout: %C\n"), std::string(DCPS::GuidConverter(*it)).c_str()));
       if (participant_sec_attr_.allow_unauthenticated_participants == false) {
+        ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+        if (endpoint) {
+          stop_ice(endpoint, pit->first, pit->second.pdata_.participantProxy.availableBuiltinEndpoints);
+        }
         remove_discovered_participant(pit);
       } else {
         pit->second.auth_state_ = DCPS::AS_UNAUTHENTICATED;
@@ -1119,6 +1153,11 @@ Spdp::remove_expired_participants()
             ACE_TEXT("participant %C exceeded lease duration, removing\n"),
             OPENDDS_STRING(conv).c_str()));
         }
+        ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+        if (endpoint) {
+          stop_ice(endpoint, part->first, part->second.pdata_.participantProxy.availableBuiltinEndpoints);
+
+        }
         remove_discovered_participant(part);
       }
     }
@@ -1413,7 +1452,7 @@ Spdp::SpdpTransport::open()
   disco_resend_period_ = outer_->disco_->resend_period();
   last_disco_resend_ = 0;
 
-  ACE_Time_Value timer_period = disco_resend_period_ < MAX_SPDP_TIMER_PERIOD ? disco_resend_period_ : MAX_SPDP_TIMER_PERIOD;
+  ACE_Time_Value timer_period = disco_resend_period_ < outer_->disco_->max_spdp_timer_period() ? disco_resend_period_ : outer_->disco_->max_spdp_timer_period();
 
   if (-1 == reactor->schedule_timer(this, 0, ACE_Time_Value(0), timer_period)) {
     throw std::runtime_error("failed to schedule timer with reactor");
@@ -1528,6 +1567,18 @@ Spdp::SpdpTransport::write_i()
       ACE_TEXT("failed to convert from SPDPdiscoveredParticipantData ")
       ACE_TEXT("to ParameterList\n")));
     return;
+  }
+
+  ICE::Endpoint* endpoint = outer_->sedp_.get_ice_endpoint();
+  if (endpoint) {
+    const ICE::AgentInfo& agent_info = ICE::Agent::instance()->get_local_agent_info(endpoint);
+    if (ParameterListConverter::to_param_list(agent_info, plist) < 0) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
+                 ACE_TEXT("Spdp::SpdpTransport::write() - ")
+                 ACE_TEXT("failed to convert from ICE::AgentInfo ")
+                 ACE_TEXT("to ParameterList\n")));
+      return;
+    }
   }
 
   wbuff_.reset();
@@ -1708,6 +1759,18 @@ Spdp::SpdpTransport::acknowledge()
 }
 
 void
+Spdp::SpdpTransport::remove_send_addr(const ACE_INET_Addr& addr)
+{
+  send_addrs_.erase(addr);
+}
+
+void
+Spdp::SpdpTransport::insert_send_addr(const ACE_INET_Addr& addr)
+{
+  send_addrs_.insert(addr);
+}
+
+void
 Spdp::signal_liveliness(DDS::LivelinessQosPolicyKind kind)
 {
   sedp_.signal_liveliness(kind);
@@ -1885,6 +1948,265 @@ Spdp::lookup_participant_auth_state(const DCPS::RepoId& id) const
   return result;
 }
 #endif
+
+void
+Spdp::remove_send_addr(const ACE_INET_Addr& addr)
+{
+  tport_->remove_send_addr(addr);
+}
+
+void
+Spdp::add_send_addr(const ACE_INET_Addr& addr)
+{
+  tport_->insert_send_addr(addr);
+}
+
+bool
+operator==(const DCPS::Locator_t& x, const DCPS::Locator_t& y)
+{
+  return x.kind == y.kind && x.port == y.port && x.address == y.address;
+}
+
+bool
+operator!=(const DCPS::Locator_t& x, const DCPS::Locator_t& y)
+{
+  return x.kind != y.kind && x.port != y.port && x.address != y.address;
+}
+
+void
+Spdp::remove_sedp_unicast(const ACE_INET_Addr& addr)
+{
+  DCPS::Locator_t locator;
+  locator.kind = address_to_kind(addr);
+  locator.port = addr.get_port_number();
+  RTPS::address_to_bytes(locator.address, addr);
+
+  DCPS::LocatorSeq new_sedp_unicast;
+  for (size_t idx = 0; idx != sedp_unicast_.length(); ++idx) {
+    if (sedp_unicast_[idx] != locator) {
+      size_t out_idx = new_sedp_unicast.length();
+      new_sedp_unicast.length(out_idx + 1);
+      new_sedp_unicast[out_idx] = sedp_unicast_[idx];
+    }
+  }
+
+  sedp_unicast_ = new_sedp_unicast;
+}
+
+void
+Spdp::add_sedp_unicast(const ACE_INET_Addr& addr)
+{
+  DCPS::Locator_t locator;
+  locator.kind = address_to_kind(addr);
+  locator.port = addr.get_port_number();
+  RTPS::address_to_bytes(locator.address, addr);
+
+  size_t idx = sedp_unicast_.length();
+  sedp_unicast_.length(idx + 1);
+  sedp_unicast_[idx] = locator;
+}
+
+void Spdp::start_ice(ICE::Endpoint * endpoint, RepoId r, BuiltinEndpointSet_t const & avail, ICE::AgentInfo const & agent_info) {
+  RepoId l = guid_;
+
+  // See RTPS v2.1 section 8.5.5.1
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+
+#ifdef OPENDDS_SECURITY
+  using namespace DDS::Security;
+  // See DDS-Security v1.1 section 7.3.7.1
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+#endif
+}
+
+void Spdp::stop_ice(ICE::Endpoint * endpoint, DCPS::RepoId r, BuiltinEndpointSet_t const & avail) {
+  RepoId l = guid_;
+
+  // See RTPS v2.1 section 8.5.5.1
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+
+#ifdef OPENDDS_SECURITY
+  using namespace DDS::Security;
+  // See DDS-Security v1.1 section 7.3.7.1
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+#endif
+}
 
 }
 }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -1,3 +1,5 @@
+
+
 /*
  *
  *
@@ -118,6 +120,11 @@ public:
   DCPS::AuthState lookup_participant_auth_state(const DCPS::RepoId& id) const;
 #endif
 
+  void remove_send_addr(const ACE_INET_Addr& addr);
+  void add_send_addr(const ACE_INET_Addr& addr);
+  void remove_sedp_unicast(const ACE_INET_Addr& addr);
+  void add_sedp_unicast(const ACE_INET_Addr& addr);
+
 protected:
   Sedp& endpoint_manager() { return sedp_; }
 
@@ -173,6 +180,8 @@ private:
     void dispose_unregister();
     bool open_unicast_socket(u_short port_common, u_short participant_id);
     void acknowledge();
+    void remove_send_addr(const ACE_INET_Addr& addr);
+    void insert_send_addr(const ACE_INET_Addr& addr);
 
     Spdp* outer_;
     Header hdr_;
@@ -216,6 +225,9 @@ private:
 
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;
 #endif
+
+  void start_ice(ICE::Endpoint * endpoint, DCPS::RepoId remote, BuiltinEndpointSet_t const & avail, ICE::AgentInfo const & agent_info);
+  void stop_ice(ICE::Endpoint * endpoint, DCPS::RepoId remote, BuiltinEndpointSet_t const & avail);
 };
 
 }

--- a/dds/DCPS/RTPS/rtps.mpc
+++ b/dds/DCPS/RTPS/rtps.mpc
@@ -1,4 +1,4 @@
-project(OpenDDS_Rtps): dcpslib, install, rtps_optional_safety {
+project(OpenDDS_Rtps): dcpslib, install, rtps_optional_safety, dcps_ice {
   sharedname = OpenDDS_Rtps
   dynamicflags = OPENDDS_RTPS_BUILD_DLL
 

--- a/dds/DCPS/RecorderImpl.h
+++ b/dds/DCPS/RecorderImpl.h
@@ -135,6 +135,8 @@ public:
                                      const RepoId& /*readerid*/,
                                      const RepoId& /*writerid*/);
 
+  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+
 protected:
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);
   void remove_publication(const PublicationId& pub_id);

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -157,6 +157,8 @@ public:
                                      const RepoId& writerid,
                                      const RepoId& readerid);
 
+  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+
   DDS::ReturnCode_t enable();
 
   DomainParticipantImpl*          participant() {

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -346,15 +346,8 @@ StaticEndpointManager::add_publication_i(const RepoId& writerid,
 }
 
 DDS::ReturnCode_t
-StaticEndpointManager::remove_publication_i(const RepoId& writerid)
+StaticEndpointManager::remove_publication_i(const RepoId& writerid, LocalPublication& pub)
 {
-  LocalPublicationMap::const_iterator lp_pos = local_publications_.find(writerid);
-  if (lp_pos == local_publications_.end()) {
-    return DDS::RETCODE_ERROR;
-  }
-
-  const LocalPublication& pub = lp_pos->second;
-
   EndpointRegistry::WriterMapType::const_iterator pos = registry_.writer_map.find(writerid);
   if (pos == registry_.writer_map.end()) {
     return DDS::RETCODE_ERROR;
@@ -422,15 +415,9 @@ StaticEndpointManager::add_subscription_i(const RepoId& readerid,
 }
 
 DDS::ReturnCode_t
-StaticEndpointManager::remove_subscription_i(const RepoId& readerid)
+StaticEndpointManager::remove_subscription_i(const RepoId& readerid,
+                                             LocalSubscription& sub)
 {
-  LocalSubscriptionMap::const_iterator ls_pos = local_subscriptions_.find(readerid);
-  if (ls_pos == local_subscriptions_.end()) {
-    return DDS::RETCODE_ERROR;
-  }
-
-  const LocalSubscription& sub = ls_pos->second;
-
   EndpointRegistry::ReaderMapType::const_iterator pos = registry_.reader_map.find(readerid);
   if (pos == registry_.reader_map.end()) {
     return DDS::RETCODE_ERROR;

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -172,12 +172,14 @@ public:
   virtual DDS::ReturnCode_t add_publication_i(const RepoId& /*rid*/,
                                               LocalPublication& /*pub*/);
 
-  virtual DDS::ReturnCode_t remove_publication_i(const RepoId& /*publicationId*/);
+  virtual DDS::ReturnCode_t remove_publication_i(const RepoId& /*publicationId*/,
+                                                 LocalPublication& /*pub*/);
 
   virtual DDS::ReturnCode_t add_subscription_i(const RepoId& /*rid*/,
                                                LocalSubscription& /*pub*/);
 
-  virtual DDS::ReturnCode_t remove_subscription_i(const RepoId& /*subscriptionId*/);
+  virtual DDS::ReturnCode_t remove_subscription_i(const RepoId& /*subscriptionId*/,
+                                                  LocalSubscription& /*sub*/);
 
   virtual bool shutting_down() const;
 

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -24,6 +24,7 @@
 #include "TransportSendListener.h"
 #include "TransportReceiveListener.h"
 #include "dds/DCPS/transport/framework/QueueTaskBase_T.h"
+#include "dds/DCPS/ICE/Ice.h"
 
 #include "ace/Event_Handler.h"
 #include "ace/Synch_Traits.h"
@@ -254,6 +255,8 @@ public:
   void set_scheduling_release(bool scheduling_release);
 
   virtual void send_final_acks (const RepoId& readerid);
+
+  virtual ICE::Endpoint* get_ice_endpoint() const { return 0; }
 
 protected:
 

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -687,6 +687,21 @@ TransportClient::unregister_for_writer(const RepoId& participant,
   }
 }
 
+ICE::Endpoint*
+TransportClient::get_ice_endpoint()
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, lock_, 0);
+  for (ImplsType::iterator pos = impls_.begin(), limit = impls_.end();
+       pos != limit;
+       ++pos) {
+    ICE::Endpoint* endpoint = (*pos)->get_ice_endpoint();
+    if (endpoint) { return endpoint; }
+  }
+
+  // TODO(jrw972):  This should return a set.  How would the semantics change?
+  return 0;
+}
+
 bool
 TransportClient::send_response(const RepoId& peer,
                                const DataSampleHeader& header,

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -101,6 +101,8 @@ public:
                              const RepoId& readerid,
                              const RepoId& writerid);
 
+  ICE::Endpoint* get_ice_endpoint();
+
   // Data transfer:
 
   bool send_response(const RepoId& peer,

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -153,6 +153,8 @@ public:
     DataLink_rch link_;
   };
 
+  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+
 protected:
   TransportImpl(TransportInst& config);
 

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -126,7 +126,9 @@ private:
   void shutdown();
 
   friend class TransportClient;
+ protected:
   TransportImpl* impl();
+ private:
   virtual TransportImpl_rch new_impl() = 0;
 
   const OPENDDS_STRING name_;

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -302,10 +302,16 @@ TransportReceiveStrategy<TH, DSH>::handle_dds_input(ACE_HANDLE fd)
   // Read into the buffers.
   //
   ACE_INET_Addr remote_address;
+  bool stop = false;
   ssize_t bytes_remaining = this->receive_bytes(iov,
                                                 static_cast<int>(vec_index),
                                                 remote_address,
-                                                fd);
+                                                fd,
+                                                stop);
+
+  if (stop) {
+    return 0;
+  }
 
   if (bytes_remaining < 0) {
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Problem ")

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -61,7 +61,8 @@ protected:
   virtual ssize_t receive_bytes(iovec          iov[],
                                 int            n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE     fd) = 0;
+                                ACE_HANDLE     fd,
+                                bool&          stop) = 0;
 
   /// Check the transport header for suitability.
   virtual bool check_header(const TH& header);

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
@@ -43,7 +43,8 @@ ssize_t
 MulticastReceiveStrategy::receive_bytes(iovec iov[],
                                         int n,
                                         ACE_INET_Addr& remote_address,
-                                        ACE_HANDLE /*fd*/)
+                                        ACE_HANDLE /*fd*/,
+                                        bool& /*stop*/)
 {
   ACE_SOCK_Dgram_Mcast& socket = this->link_->socket();
   return socket.recv(iov, n, remote_address);

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
@@ -34,7 +34,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual bool check_header(const TransportHeader& header);
   virtual bool check_header(const DataSampleHeader& header);

--- a/dds/DCPS/transport/rtps_udp/OpenDDS_Rtps_Udp.mpc
+++ b/dds/DCPS/transport/rtps_udp/OpenDDS_Rtps_Udp.mpc
@@ -1,7 +1,7 @@
 //
 //
 
-project: dcpslib, dcps_rtps, install {
+project: dcpslib, dcps_rtps, dcps_ice, install {
   sharedname    = OpenDDS_Rtps_Udp
   dynamicflags  = OPENDDS_RTPS_UDP_BUILD_DLL
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -39,6 +39,8 @@
 #include "dds/DCPS/security/framework/SecurityConfig_rch.h"
 #endif
 
+#include "dds/DCPS/ICE/Ice.h"
+
 class DDS_TEST;
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -98,13 +100,11 @@ public:
   void add_locator(const RepoId& remote_id, const ACE_INET_Addr& address,
                    bool requires_inline_qos);
 
-  /// Given a 'local_id' of a publication or subscription, populate the set of
-  /// 'addrs' with the network addresses of any remote peers (or if 'local_id'
-  /// is GUID_UNKNOWN, all known addresses).
-  void get_locators(const RepoId& local_id,
-                    OPENDDS_SET(ACE_INET_Addr)& addrs) const;
-
-  ACE_INET_Addr get_locator(const RepoId& remote_id) const;
+  /// Given a 'local' id and a 'remote' id of a publication or
+  /// subscription, return the set of addresses of the remote peers.
+  OPENDDS_SET(ACE_INET_Addr) get_addresses(RepoId const & local, RepoId const & remote) const;
+  /// Given a 'local' id, return the set of address for all remote peers.
+  OPENDDS_SET(ACE_INET_Addr) get_addresses(RepoId const & local) const;
 
   void associated(const RepoId& local, const RepoId& remote,
                   bool local_reliable, bool remote_reliable,
@@ -131,6 +131,8 @@ public:
   virtual void pre_stop_i();
 
   virtual void send_final_acks(const RepoId& readerid);
+
+  virtual ICE::Endpoint* get_ice_endpoint() const;
 
 #ifdef OPENDDS_SECURITY
   Security::SecurityConfig_rch security_config() const
@@ -326,7 +328,7 @@ private:
                                   const DisjointSequence& gaps,
                                   bool durable = false);
 
-  void send_nackfrag_replies(RtpsWriter& writer, DisjointSequence& gaps,
+  void send_nackfrag_replies(RtpsWriterMap::iterator rw_iter, DisjointSequence& gaps,
                              OPENDDS_SET(ACE_INET_Addr)& gap_recipients);
 
   template<typename T, typename FN>
@@ -546,6 +548,7 @@ private:
                           GUID_tKeyLessThan)::const_iterator PeerHandlesCIter;
 #endif
 
+  void get_addresses_i(RepoId const & local, RepoId const & remote, OPENDDS_SET(ACE_INET_Addr) & addresses) const;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -13,6 +13,8 @@
 #include "dds/DCPS/transport/framework/TransportInst.h"
 #include "dds/DCPS/SafetyProfileStreams.h"
 
+#include "dds/DCPS/ICE/Stun.h"
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -69,10 +71,12 @@ public:
     set_port_in_addr_string(local_address_config_str_, port_number);
   }
 
-  /// Relay address may change, these use a mutex
+  /// Relay address and stun server address may change, these use a mutex
   ///{
   void rtps_relay_address(const ACE_INET_Addr& address);
   ACE_INET_Addr rtps_relay_address() const;
+  void stun_server_address(const ACE_INET_Addr& address);
+  ACE_INET_Addr stun_server_address() const;
   ///}
 
 private:
@@ -91,6 +95,10 @@ private:
   ACE_INET_Addr local_address_;
   OPENDDS_STRING local_address_config_str_;
   ACE_INET_Addr rtps_relay_address_;
+  bool use_ice_;
+  ACE_INET_Addr stun_server_address_;
+
+  ICE::AddressListType host_addresses() const;
 };
 
 inline void RtpsUdpInst::rtps_relay_address(const ACE_INET_Addr& address)
@@ -103,6 +111,18 @@ inline ACE_INET_Addr RtpsUdpInst::rtps_relay_address() const
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
   return rtps_relay_address_;
+}
+
+inline void RtpsUdpInst::stun_server_address(const ACE_INET_Addr& address)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  stun_server_address_ = address;
+}
+
+inline ACE_INET_Addr RtpsUdpInst::stun_server_address() const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+  return stun_server_address_;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -21,7 +21,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const GuidPrefix_t& local_prefix)
+  RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const GuidPrefix_t& local_prefix)
   : link_(link)
   , last_received_()
   , recvd_sample_(0)
@@ -42,10 +42,57 @@ RtpsUdpReceiveStrategy::handle_input(ACE_HANDLE fd)
 }
 
 ssize_t
+RtpsUdpReceiveStrategy::receive_bytes_helper(iovec iov[],
+                                             int n,
+                                             ACE_SOCK_Dgram const & socket,
+                                             ACE_INET_Addr & remote_address,
+                                             ICE::Endpoint * endpoint,
+                                             bool & stop)
+{
+  ACE_INET_Addr local_address;
+  const ssize_t ret = socket.recv(iov, n, remote_address, 0, &local_address);
+
+  if (ret == -1) {
+    return ret;
+  }
+
+  if (endpoint && n > 0 && ret > 0 && iov[0].iov_len >= 4 && memcmp(iov[0].iov_base, "RTPS", 4) != 0) {
+    // Assume STUN
+    stop = true;
+    size_t bytes = ret;
+    size_t block_size = std::min(bytes, static_cast<size_t>(iov[0].iov_len));
+    ACE_Message_Block* head = new ACE_Message_Block(static_cast<const char*>(iov[0].iov_base), block_size);
+    head->length(block_size);
+    bytes -= block_size;
+
+    ACE_Message_Block* tail = head;
+    for (int i = 1; i < n && bytes != 0; ++i) {
+      block_size = std::min(bytes, static_cast<size_t>(iov[i].iov_len));
+      ACE_Message_Block* mb = new ACE_Message_Block(static_cast<const char*>(iov[i].iov_base), block_size);
+      mb->length(block_size);
+      tail->cont(mb);
+      tail = mb;
+      bytes -= block_size;
+    }
+
+    DCPS::Serializer serializer(head, true);
+    STUN::Message message;
+    message.block = head;
+    if (serializer >> message) {
+      ICE::Agent::instance()->receive(endpoint, local_address, remote_address, message);
+    }
+    head->release();
+  }
+
+  return ret;
+}
+
+ssize_t
 RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
                                       int n,
                                       ACE_INET_Addr& remote_address,
-                                      ACE_HANDLE fd)
+                                      ACE_HANDLE fd,
+                                      bool& stop)
 {
   const ACE_SOCK_Dgram& socket =
     (fd == link_->unicast_socket().get_handle())
@@ -63,9 +110,10 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
   }
   const ssize_t ret = (scatter < 0) ? scatter : (iter - buffer);
 #else
-  const ssize_t ret = socket.recv(iov, n, remote_address);
+  const ssize_t ret = receive_bytes_helper(iov, n, socket, remote_address, link_->get_ice_endpoint(), stop);
 #endif
   remote_address_ = remote_address;
+
   return ret;
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -17,7 +17,10 @@
 #include "dds/DCPS/RTPS/RtpsCoreC.h"
 #include "dds/DCPS/RcEventHandler.h"
 
+#include "dds/DCPS/ICE/Ice.h"
+
 #include "ace/INET_Addr.h"
+#include "ace/SOCK_Dgram.h"
 
 #include <cstring>
 
@@ -62,11 +65,19 @@ public:
   const ReceivedDataSample* withhold_data_from(const RepoId& sub_id);
   void do_not_withhold_data_from(const RepoId& sub_id);
 
+  static ssize_t receive_bytes_helper(iovec iov[],
+                                      int n,
+                                      ACE_SOCK_Dgram const & socket,
+                                      ACE_INET_Addr & remote_address,
+                                      ICE::Endpoint * endpoint,
+                                      bool & stop);
+
 private:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -84,9 +84,6 @@ ssize_t
 RtpsUdpSendStrategy::send_bytes_i_helper(const iovec iov[], int n)
 {
   if (override_single_dest_) {
-    if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
-      send_single_i(iov, n, link_->config().rtps_relay_address());
-    }
     return send_single_i(iov, n, *override_single_dest_);
   }
 
@@ -101,18 +98,11 @@ RtpsUdpSendStrategy::send_bytes_i_helper(const iovec iov[], int n)
     return -1;
   }
 
-  const RepoId remote_id = elem->subscription_id();
   OPENDDS_SET(ACE_INET_Addr) addrs;
-
-  if (remote_id != GUID_UNKNOWN) {
-    const ACE_INET_Addr remote = link_->get_locator(remote_id);
-    if (remote != ACE_INET_Addr()) {
-      addrs.insert(remote);
-    }
-  }
-
-  if (addrs.empty()) {
-    link_->get_locators(elem->publication_id(), addrs);
+  if (elem->subscription_id() != GUID_UNKNOWN) {
+    addrs = link_->get_addresses(elem->publication_id(), elem->subscription_id());
+  } else {
+    addrs = link_->get_addresses(elem->publication_id());
   }
 
   if (addrs.empty()) {
@@ -165,9 +155,6 @@ RtpsUdpSendStrategy::send_rtps_control(ACE_Message_Block& submessages,
 
   iovec iov[MAX_SEND_BLOCKS];
   const int num_blocks = mb_to_iov(use_mb, iov);
-  if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
-    send_single_i(iov, num_blocks, link_->config().rtps_relay_address());
-  }
   const ssize_t result = send_single_i(iov, num_blocks, addr);
   if (result < 0) {
     const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
@@ -206,9 +193,6 @@ ssize_t
 RtpsUdpSendStrategy::send_multi_i(const iovec iov[], int n,
                                   const OPENDDS_SET(ACE_INET_Addr)& addrs)
 {
-  if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
-    send_single_i(iov, n, link_->config().rtps_relay_address());
-  }
   ssize_t result = -1;
   typedef OPENDDS_SET(ACE_INET_Addr)::const_iterator iter_t;
   for (iter_t iter = addrs.begin(); iter != addrs.end(); ++iter) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
@@ -18,6 +18,8 @@
 
 #include "dds/DCPS/RTPS/MessageTypes.h"
 
+#include "dds/DCPS/ICE/Stun.h"
+
 #include "ace/INET_Addr.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -33,6 +33,7 @@ RtpsUdpTransport::RtpsUdpTransport(RtpsUdpInst& inst)
 #if defined(OPENDDS_SECURITY)
   , local_crypto_handle_(DDS::HANDLE_NIL)
 #endif
+  , ice_endpoint_(*this)
 {
   if (! (configure_i(inst) && open())) {
     throw Transport::UnableToCreate();
@@ -45,6 +46,12 @@ RtpsUdpTransport::config() const
   return static_cast<RtpsUdpInst&>(TransportImpl::config());
 }
 
+ICE::Endpoint*
+RtpsUdpTransport::get_ice_endpoint()
+{
+  return (config().use_ice_) ? &ice_endpoint_ : 0;
+}
+
 RtpsUdpDataLink_rch
 RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 {
@@ -55,6 +62,17 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
   link->local_crypto_handle(local_crypto_handle_);
 #endif
 
+  if (config().use_ice_) {
+    if (reactor()->remove_handler(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("(%P|%t) ERROR: ")
+                        ACE_TEXT("RtpsUdpReceiveStrategy::start_i: ")
+                        ACE_TEXT("failed to unregister handler for unicast ")
+                        ACE_TEXT("socket %d\n"),
+                        unicast_socket_.get_handle()),
+                       RtpsUdpDataLink_rch());
+    }
+  }
   if (!link->open(unicast_socket_)) {
     ACE_ERROR((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
@@ -290,6 +308,17 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
                       false);
   }
 
+#if defined (ACE_RECVPKTINFO)
+  int sockopt = 1;
+  if (unicast_socket_.set_option(IPPROTO_IP, ACE_RECVPKTINFO, &sockopt, sizeof sockopt) == -1) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("(%P|%t) ERROR: ")
+                      ACE_TEXT("RtpsUdpTransport::configure_i: setcokopt:")
+                      ACE_TEXT("%m\n")),
+                     false);
+  }
+#endif
+
   if (config.local_address().get_port_number() == 0) {
 
     ACE_INET_Addr address;
@@ -302,6 +331,20 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
   }
 
   create_reactor_task();
+
+  if (config.use_ice_) {
+    ICE::Agent::instance()->add_endpoint(&ice_endpoint_);
+    if (reactor()->register_handler(unicast_socket_.get_handle(), &ice_endpoint_,
+                                    ACE_Event_Handler::READ_MASK) != 0) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("(%P|%t) ERROR: ")
+                        ACE_TEXT("RtpsUdpReceiveStrategy::start_i: ")
+                        ACE_TEXT("failed to register handler for unicast ")
+                        ACE_TEXT("socket %d\n"),
+                        unicast_socket_.get_handle()),
+                       false);
+    }
+  }
 
   if (config.opendds_discovery_default_listener_) {
     link_= make_datalink(config.opendds_discovery_guid_.guidPrefix);
@@ -318,6 +361,10 @@ RtpsUdpTransport::shutdown_i()
     link_->transport_shutdown();
   }
   link_.reset();
+
+  if(config().use_ice_) {
+    ICE::Agent::instance()->remove_endpoint(&ice_endpoint_);
+  }
 }
 
 void
@@ -339,6 +386,89 @@ RtpsUdpTransport::map_ipv4_to_ipv6() const
   }
   return map;
 }
+
+int
+RtpsUdpTransport::IceEndpoint::handle_input(ACE_HANDLE /*fd*/)
+{
+  struct iovec        iov[1];
+  char buffer[0x10000];
+  iov[0].iov_base = buffer;
+  iov[0].iov_len  = sizeof buffer;
+  ACE_INET_Addr remote_address;
+
+  bool stop;
+  RtpsUdpReceiveStrategy::receive_bytes_helper(iov, 1, transport.unicast_socket_, remote_address, transport.get_ice_endpoint(), stop);
+
+  return 0;
+}
+
+namespace {
+  bool shouldWarn(int code) {
+    return code == EPERM || code == EACCES || code == EINTR || code == ENOBUFS || code == ENOMEM;
+  }
+
+  ssize_t
+  send_single_i(ACE_SOCK_Dgram& socket, const iovec iov[], int n, const ACE_INET_Addr& addr)
+  {
+#ifdef ACE_LACKS_SENDMSG
+    char buffer[UDP_MAX_MESSAGE_SIZE];
+    char *iter = buffer;
+    for (int i = 0; i < n; ++i) {
+      if (size_t(iter - buffer + iov[i].iov_len) > UDP_MAX_MESSAGE_SIZE) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) RtpsUdpSendStrategy::send_single_i() - "
+                   "message too large at index %d size %d\n", i, iov[i].iov_len));
+        return -1;
+      }
+      std::memcpy(iter, iov[i].iov_base, iov[i].iov_len);
+      iter += iov[i].iov_len;
+    }
+    const ssize_t result = socket.send(buffer, iter - buffer, addr);
+#else
+    const ssize_t result = socket.send(iov, n, addr);
+#endif
+    if (result < 0) {
+      ACE_TCHAR addr_buff[256] = {};
+      int err = errno;
+      addr.addr_to_string(addr_buff, 256, 0);
+      errno = err;
+      const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
+      ACE_ERROR((prio, "(%P|%t) RtpsUdpSendStrategy::send_single_i() - "
+                 "destination %s failed %p\n", addr_buff, ACE_TEXT("send")));
+    }
+    return result;
+  }
+}
+
+ICE::AddressListType
+RtpsUdpTransport::IceEndpoint::host_addresses() const {
+  return transport.config().host_addresses();
+}
+
+void
+RtpsUdpTransport::IceEndpoint::send(const ACE_INET_Addr& destination, const STUN::Message& message)
+{
+  ACE_SOCK_Dgram& socket = (!transport.link_.is_nil()) ? transport.link_->unicast_socket() : transport.unicast_socket_;
+
+  ACE_Message_Block block(20 + message.length());
+  DCPS::Serializer serializer(&block, true);
+  const_cast<STUN::Message&>(message).block = &block;
+  serializer << message;
+
+  iovec iov[MAX_SEND_BLOCKS];
+  const int num_blocks = RtpsUdpSendStrategy::mb_to_iov(block, iov);
+  const ssize_t result = send_single_i(socket, iov, num_blocks, destination);
+  if (result < 0) {
+    const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
+    ACE_ERROR((prio, "(%P|%t) RtpsUdpTransport::send() - "
+               "failed to send STUN message\n"));
+  }
+}
+
+ACE_INET_Addr
+RtpsUdpTransport::IceEndpoint::stun_server_address() const {
+  return transport.config().stun_server_address();
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
@@ -77,7 +77,8 @@ ssize_t
 ShmemReceiveStrategy::receive_bytes(iovec iov[],
                                     int n,
                                     ACE_INET_Addr& /*remote_address*/,
-                                    ACE_HANDLE /*fd*/)
+                                    ACE_HANDLE /*fd*/,
+                                    bool& /*stop*/)
 {
   VDBG((LM_DEBUG,
         "(%P|%t) ShmemReceiveStrategy::receive_bytes link %@\n", link_));

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
@@ -33,7 +33,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
@@ -39,7 +39,8 @@ OpenDDS::DCPS::TcpReceiveStrategy::receive_bytes(
   iovec iov[],
   int   n,
   ACE_INET_Addr& /*remote_address*/,
-  ACE_HANDLE /*fd*/)
+  ACE_HANDLE /*fd*/,
+  bool& /*stop*/)
 {
   DBG_ENTRY_LVL("TcpReceiveStrategy", "receive_bytes", 6);
 

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
@@ -43,7 +43,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int   n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
@@ -38,7 +38,8 @@ ssize_t
 UdpReceiveStrategy::receive_bytes(iovec iov[],
                                   int n,
                                   ACE_INET_Addr& remote_address,
-                                  ACE_HANDLE /*fd*/)
+                                  ACE_HANDLE /*fd*/,
+                                  bool& /*stop*/)
 {
   const ssize_t ret = this->link_->socket().recv(iov, n, remote_address);
   remote_address_ = remote_address;

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.h
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.h
@@ -36,7 +36,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/tests/DCPS/Messenger/rtps_disc.ini
+++ b/tests/DCPS/Messenger/rtps_disc.ini
@@ -7,7 +7,9 @@ DiscoveryConfig=uni_rtps
 [rtps_discovery/uni_rtps]
 SedpMulticast=0
 ResendPeriod=2
+SedpStunServerAddress=10.201.200.156:3478
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp
 use_multicast=0
+DataStunServerAddress=10.201.200.156:3478


### PR DESCRIPTION
Participants that are behind NATs cannot communicate directly.  The
RtpsRelay solves the problem of enabling communication.  However, all
of the data transferred between the participants must pass through the
relay.  This solution provides an optimization where participants can
communicate directly after bootstrapping discovery with the RtpsRelay.

Solution: Implement ICE for RTPS.  ICE involves exchanging candidate
information and then performing connectivity checks to determine a
pair of candidates that can be used to exchange data.  Candidate
information is exchange via SPDP; presumably by using the RtpsRelay.
ICE is then attempted for SEDP.  Similarly, SEDP is used to exchange
candidate information for the data transport.  ICE is then attempted
for the data transports.